### PR TITLE
Remove useless code from retrieving the function info data

### DIFF
--- a/Profiler/CProfilerCallback.h
+++ b/Profiler/CProfilerCallback.h
@@ -77,9 +77,6 @@ private:
 	/** Default size for arrays. */
 	static const int BUFFER_SIZE = 2048;
 
-	/** Counts the number of assemblies loaded. */
-	int assemblyCounter = 1;
-
 	/** Whether to run in light mode or force re-jitting of pre-jitted methods. */
 	bool isLightMode = false;
 
@@ -91,12 +88,6 @@ private:
 
 	/** Whether the current process should be profiled. */
 	bool isProfilingEnabled = false;
-
-	/**
-	 * Maps from assembly IDs to assemblyNumbers (determined by assemblyCounter).
-	 * It is used to identify the declaring assembly for functions.
-	 */
-	std::map<AssemblyID, int> assemblyMap;
 
 	/**
 	 * Info object that keeps track of jitted methods.
@@ -151,9 +142,6 @@ private:
 
 	/** Create the log file and add general information. */
 	void createLogFile();
-
-	/**  Store assembly counter for id. */
-	int registerAssembly(AssemblyID assemblyId);
 
 	/** Stores the assmebly name, path and metadata in the passed variables.*/
 	void getAssemblyInfo(AssemblyID assemblyId, WCHAR* assemblyName, WCHAR *assemblyPath, ASSEMBLYMETADATA* moduleId);

--- a/Profiler/FunctionInfo.h
+++ b/Profiler/FunctionInfo.h
@@ -8,8 +8,8 @@
  */
 struct FunctionInfo {
 
-	/** Index into the assemblyMap of the assembly that contains the function. */
-	int assemblyNumber;
+	/** The assembly ID that contains the function. */
+	AssemblyID assemblyID;
 
 	/** Metadata token of the function. */
 	mdToken functionToken;


### PR DESCRIPTION
Retrieving the function info data contained some code that should not be needed anymore. I guess this was once needed to also display the assembly or method name in the trace. But as we use assembly ids now, most of it can be removed.

One could also think of directly using the .net provided assembly id instead of providing an own mapping?

Tested the modification with diffing the trace file of one of our tests and the result looks reasonable.

[coverage_20180716_1408310030.txt](https://github.com/cqse/teamscale-profiler-dotnet/files/2198013/coverage_20180716_1408310030.txt)
[coverage_20180716_1415480335.txt](https://github.com/cqse/teamscale-profiler-dotnet/files/2198014/coverage_20180716_1415480335.txt)

