### PR TITLE
Upload traces to an Azure File Storage

### DIFF
--- a/UploadDaemon/AzureFileStorage.cs
+++ b/UploadDaemon/AzureFileStorage.cs
@@ -1,0 +1,26 @@
+﻿using Newtonsoft.Json;
+
+/// <summary>
+/// Data class that holds all details necessary to connect to an Azure File Storage.
+/// </summary>
+public class AzureFileStorage
+{
+	/// <summary>
+	/// Connection string for a file storage. For details on how to create connection strings,
+	/// refer to https://docs.microsoft.com/en-us/azure/storage/common/storage-configure-connection-string.
+	/// </summary>
+	[JsonProperty(Required = Required.Always)]
+	public string ConnectionString { get; set; }
+
+	/// <summary>
+	/// Name of the file-storage share to write to.
+	/// </summary>
+	[JsonProperty(Required = Required.Always)]
+	public string ShareName { get; set; }
+
+	/// <summary>
+	/// Directory within the storage share to write into.
+	/// </summary>
+	[JsonProperty(Required = Required.Default)]
+	public string Directory { get; set; }
+}

--- a/UploadDaemon/Config.cs
+++ b/UploadDaemon/Config.cs
@@ -37,6 +37,11 @@ public class Config
     /// </summary>
     public string FileUpload { get; set; } = null;
 
+	/// <summary>
+	/// The Azure File Storage to upload to.
+	/// </summary>
+	public AzureFileStorage AzureFileStorage { get; set; } = null;
+
     /// <summary>
     /// Validates the configuration and returns all collected error messages. An empty list
     /// means the configuration is valid.
@@ -68,6 +73,10 @@ public class Config
         {
             return new UploadServiceUpload(FileUpload);
         }
+		if (AzureFileStorage != null)
+		{
+			return new AzureUpload(AzureFileStorage);
+		}
         return new FileSystemUpload(Directory, fileSystem);
     }
 

--- a/UploadDaemon/Config.cs
+++ b/UploadDaemon/Config.cs
@@ -49,9 +49,14 @@ public class Config
     /// <returns></returns>
     public IEnumerable<string> Validate()
     {
-        if (Teamscale == null && Directory == null && FileUpload == null)
+        if (Teamscale == null && Directory == null && FileUpload == null && AzureFileStorage == null)
         {
-            yield return @"You must provide either a Teamscale server (property ""teamscale"") or a directory (property ""directory"") or an HTTP endpoint (property ""fileUpload"") to upload trace files to.";
+            yield return @"You must provide either" +
+				@" a Teamscale server (property ""teamscale"")" +
+				@" or a directory (property ""directory"")" +
+				@" or an HTTP endpoint (property ""fileUpload"")" +
+				@" or an Azure File Storage (property ""azureFileStorage"")" +
+				@" to upload trace files to.";
         }
         if (VersionAssembly == null)
         {

--- a/UploadDaemon/UploadDaemon.csproj
+++ b/UploadDaemon/UploadDaemon.csproj
@@ -67,6 +67,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Archiver.cs" />
+	<Compile Include="AzureFileStorage.cs" />
     <Compile Include="Config.cs" />
     <Compile Include="MessageFormatter.cs" />
     <Compile Include="TimerAction.cs" />

--- a/UploadDaemon/UploadDaemon.csproj
+++ b/UploadDaemon/UploadDaemon.csproj
@@ -35,6 +35,12 @@
     <StartupObject />
   </PropertyGroup>
   <ItemGroup>
+     <Reference Include="Microsoft.Azure.Storage.Common, Version=9.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Azure.Storage.Common.9.4.0\lib\net452\Microsoft.Azure.Storage.Common.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Azure.Storage.File, Version=9.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Azure.Storage.File.9.4.0\lib\net452\Microsoft.Azure.Storage.File.dll</HintPath>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
@@ -67,6 +73,7 @@
     <Compile Include="TraceFileScanner.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TeamscaleServer.cs" />
+    <Compile Include="upload\AzureUpload.cs" />
     <Compile Include="upload\HttpClientUtils.cs" />
     <Compile Include="upload\IUpload.cs" />
     <Compile Include="upload\FileSystemUpload.cs" />

--- a/UploadDaemon/UploadDaemon.json
+++ b/UploadDaemon/UploadDaemon.json
@@ -41,5 +41,20 @@
     /* Directory to upload finished trace files to. May be a UNC path. Please escape backslashes properly!
        Delete this if you don't want to upload to a directory. This property will be ignored if a
        Teamscale server or HTTP endpoint is configured above. */
-    "directory": "C:\\some\\directory"
+    "directory": "C:\\some\\directory",
+
+    /* Connection details for upload to an Azure File Storage. Delete this if you don't want to upload to
+       an Azure File Storage. */
+    "azureFileStorage": {
+        /* Connection string to the Azure File Storage. For details on how to obtain or create a connection
+           string for your file storage, please refer to
+           https://docs.microsoft.com/en-us/azure/storage/common/storage-configure-connection-string */
+        "connectionString": "DefaultEndpointsProtocol=[http|https];AccountName=<account-name>;AccountKey=<account-key>;EndpointSuffix=core.windows.net",
+
+        /* The name of the share to upload to. */
+        "shareName": "myShare",
+
+        /* A directory within the share to upload to. Omit this to upload to the share's root directory. */
+        "directory": "path\\on\\share"
+    }
 }

--- a/UploadDaemon/packages.config
+++ b/UploadDaemon/packages.config
@@ -1,5 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net461" />
+  <package id="Microsoft.Azure.Storage.Common" version="9.4.0" targetFramework="net461" />
+  <package id="Microsoft.Azure.Storage.File" version="9.4.0" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net461" />
   <package id="NLog" version="4.5.6" targetFramework="net461" />
   <package id="System.IO.Abstractions" version="2.1.0.178" targetFramework="net461" />

--- a/UploadDaemon/packages.config
+++ b/UploadDaemon/packages.config
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-// TODO (MP) Is KeyVault used? Cannot find reference in csproj.
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net461" />
   <package id="Microsoft.Azure.Storage.Common" version="9.4.0" targetFramework="net461" />
   <package id="Microsoft.Azure.Storage.File" version="9.4.0" targetFramework="net461" />

--- a/UploadDaemon/packages.config
+++ b/UploadDaemon/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+// TODO (MP) Is KeyVault used? Cannot find reference in csproj.
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net461" />
   <package id="Microsoft.Azure.Storage.Common" version="9.4.0" targetFramework="net461" />
   <package id="Microsoft.Azure.Storage.File" version="9.4.0" targetFramework="net461" />

--- a/UploadDaemon/upload/AzureUpload.cs
+++ b/UploadDaemon/upload/AzureUpload.cs
@@ -1,0 +1,118 @@
+﻿using Microsoft.WindowsAzure.Storage;
+using Microsoft.WindowsAzure.Storage.File;
+using NLog;
+using System;
+using System.IO;
+using System.Threading.Tasks;
+
+/// <summary>
+/// Uploads trace files to an Azure File Storage.
+/// </summary>
+public class AzureUpload : IUpload
+{
+	private static readonly Logger logger = LogManager.GetCurrentClassLogger();
+
+	private readonly string storageConnectionString;
+	private readonly string shareName;
+	private readonly string directoryPath;
+
+	/// <param name="storageConnectionString">An Azure File Storage connection string. For details on how to craete
+	/// connection strings, please refer to https://docs.microsoft.com/en-us/azure/storage/common/storage-configure-connection-string.</param>
+	/// <param name="shareName">The name of a file share on the Azure connection</param>
+	/// <param name="directoryPath">A directory path below the file share to store coverage data in</param>
+	public AzureUpload(string storageConnectionString, string shareName, string directoryPath)
+	{
+		this.storageConnectionString = storageConnectionString;
+		this.shareName = shareName;
+		this.directoryPath = directoryPath;
+	}
+
+	public async Task<bool> UploadAsync(string filePath, string version)
+	{
+		try
+		{
+			CloudStorageAccount account = GetStorageAccount();
+
+			logger.Debug("Uploading {trace} to {azure}/{path}/", filePath, account.FileStorageUri, directoryPath);
+
+			CloudFileShare share = await GetOrCreateShare(account);
+			CloudFileDirectory directory = await GetOrCreateTargetDirectory(share);
+			await UploadFileAsync(filePath, directory);
+
+			logger.Info("Successfully uploaded {trace} to {azure}/{path}", filePath, account.FileStorageUri, directoryPath);
+
+			return true;
+		}
+		catch (Exception e)
+		{
+			logger.Error(e, "Upload of {trace} to Azure File Storage failed", filePath);
+			return false;
+		}
+	}
+
+	private CloudStorageAccount GetStorageAccount()
+	{
+		CloudStorageAccount account;
+		try
+		{
+			account = CloudStorageAccount.Parse(storageConnectionString);
+		}
+		catch (Exception e) when (e is ArgumentNullException || e is ArgumentException || e is FormatException)
+		{
+			// Do not include the connection string to the message as it contains the private connection key!
+			throw new UploadFailedException("Invalid Azure File Storage connection string provided.", e);
+		}
+
+		return account;
+	}
+
+	private async Task<CloudFileShare> GetOrCreateShare(CloudStorageAccount account)
+	{
+		CloudFileClient client = account.CreateCloudFileClient();
+		CloudFileShare share = client.GetShareReference(shareName);
+
+		await share.CreateIfNotExistsAsync();
+		if (!await share.ExistsAsync())
+		{
+			throw new UploadFailedException($"Share {shareName} does not exist and could not be created.");
+		}
+
+		return share;
+	}
+
+	private async Task<CloudFileDirectory> GetOrCreateTargetDirectory(CloudFileShare share)
+	{
+		CloudFileDirectory directory = share.GetRootDirectoryReference();
+
+		if (!string.IsNullOrEmpty(directoryPath))
+		{
+			directory = directory.GetDirectoryReference(directoryPath);
+		}
+
+		await directory.CreateIfNotExistsAsync();
+		if (!await directory.ExistsAsync())
+		{
+			throw new UploadFailedException($"Directory {directoryPath} does not exist and could not be created on {share}.");
+		}
+
+		return directory;
+	}
+
+	private static async Task UploadFileAsync(string sourceFilePath, CloudFileDirectory targetDirectory)
+	{
+		string fileName = Path.GetFileName(sourceFilePath);
+		CloudFile file = targetDirectory.GetFileReference(fileName);
+		await file.UploadFromFileAsync(sourceFilePath);
+	}
+
+	private class UploadFailedException : Exception
+	{
+		public UploadFailedException(string message) : base(message)
+		{
+		}
+
+		public UploadFailedException(string message, Exception innerException) : base(message, innerException)
+		{
+		}
+	}
+}

--- a/UploadDaemon/upload/AzureUpload.cs
+++ b/UploadDaemon/upload/AzureUpload.cs
@@ -27,8 +27,8 @@ public class AzureUpload : IUpload
 
 			logger.Debug("Uploading {trace} to {azure}/{directory}/", filePath, account.FileStorageUri, storage.Directory);
 
-			CloudFileShare share = await GetOrCreateShare(account);
-			CloudFileDirectory directory = await GetOrCreateTargetDirectory(share);
+			CloudFileShare share = await GetOrCreateShareAsync(account);
+			CloudFileDirectory directory = await GetOrCreateTargetDirectoryAsync(share);
 			await UploadFileAsync(filePath, directory);
 
 			logger.Info("Successfully uploaded {trace} to {azure}/{directory}", filePath, account.FileStorageUri, storage.Directory);
@@ -55,7 +55,7 @@ public class AzureUpload : IUpload
 		}
 	}
 
-	private async Task<CloudFileShare> GetOrCreateShare(CloudStorageAccount account)
+	private async Task<CloudFileShare> GetOrCreateShareAsync(CloudStorageAccount account)
 	{
 		CloudFileClient client = account.CreateCloudFileClient();
 		CloudFileShare share = client.GetShareReference(storage.ShareName);
@@ -69,7 +69,7 @@ public class AzureUpload : IUpload
 		return share;
 	}
 
-	private async Task<CloudFileDirectory> GetOrCreateTargetDirectory(CloudFileShare share)
+	private async Task<CloudFileDirectory> GetOrCreateTargetDirectoryAsync(CloudFileShare share)
 	{
 		CloudFileDirectory directory = share.GetRootDirectoryReference();
 

--- a/UploadDaemon/upload/AzureUpload.cs
+++ b/UploadDaemon/upload/AzureUpload.cs
@@ -78,14 +78,18 @@ public class AzureUpload : IUpload
 			directory = directory.GetDirectoryReference(storage.Directory);
 		}
 
-		// TODO (MP) does this work if we have specified a longer path, e.g. share/sub/folder?
-		await directory.CreateIfNotExistsAsync();
-		if (!await directory.ExistsAsync())
-		{
-			throw new UploadFailedException($"Directory {storage.Directory} does not exist and could not be created on {storage.ShareName}.");
-		}
+		await CreateRecursiveIfNotExistsAsync(directory);
 
 		return directory;
+	}
+
+	private async Task CreateRecursiveIfNotExistsAsync(CloudFileDirectory directory)
+	{
+		if (!await directory.ExistsAsync())
+		{
+			await CreateRecursiveIfNotExistsAsync(directory.Parent);
+			await directory.CreateAsync();
+		}
 	}
 
 	private static async Task UploadFileAsync(string sourceFilePath, CloudFileDirectory targetDirectory)

--- a/UploadDaemon/upload/AzureUpload.cs
+++ b/UploadDaemon/upload/AzureUpload.cs
@@ -44,19 +44,15 @@ public class AzureUpload : IUpload
 
 	private CloudStorageAccount GetStorageAccount()
 	{
-		CloudStorageAccount account;
 		try
 		{
-			// TODO (MP) I think you can return here immediately
-			account = CloudStorageAccount.Parse(storage.ConnectionString);
+			return CloudStorageAccount.Parse(storage.ConnectionString);
 		}
 		catch (Exception e) when (e is ArgumentNullException || e is ArgumentException || e is FormatException)
 		{
 			// Do not include the connection string to the message as it contains the private connection key!
 			throw new UploadFailedException("Invalid Azure File Storage connection string provided.", e);
 		}
-
-		return account;
 	}
 
 	private async Task<CloudFileShare> GetOrCreateShare(CloudStorageAccount account)

--- a/UploadDaemon/upload/AzureUpload.cs
+++ b/UploadDaemon/upload/AzureUpload.cs
@@ -47,6 +47,7 @@ public class AzureUpload : IUpload
 		CloudStorageAccount account;
 		try
 		{
+			// TODO (MP) I think you can return here immediately
 			account = CloudStorageAccount.Parse(storage.ConnectionString);
 		}
 		catch (Exception e) when (e is ArgumentNullException || e is ArgumentException || e is FormatException)
@@ -81,6 +82,7 @@ public class AzureUpload : IUpload
 			directory = directory.GetDirectoryReference(storage.Directory);
 		}
 
+		// TODO (MP) does this work if we have specified a longer path, e.g. share/sub/folder?
 		await directory.CreateIfNotExistsAsync();
 		if (!await directory.ExistsAsync())
 		{

--- a/UploadDaemon/upload/AzureUpload.cs
+++ b/UploadDaemon/upload/AzureUpload.cs
@@ -37,7 +37,7 @@ public class AzureUpload : IUpload
 		}
 		catch (Exception e)
 		{
-			logger.Error(e, "Upload of {trace} to Azure File Storage failed", filePath);
+			logger.Error(e, "Upload of {trace} to Azure File Storage failed: {message}", filePath, e.Message);
 			return false;
 		}
 	}

--- a/UploadDaemon_Test/ConfigTest.cs
+++ b/UploadDaemon_Test/ConfigTest.cs
@@ -33,6 +33,28 @@ public class ConfigTest
     }
 
     [Test]
+	public void AzureFileStorageUploadConfigurationIsValid()
+	{
+		IFileSystem fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>()
+		{
+			{
+				Config.ConfigFilePath, new MockFileData(@"{
+                    /* line comment */
+                    versionAssembly: ""Assembly"",
+                    azureFileStorage: {
+                        connectionString: ""<connection-string>"",
+                        shareName: ""<share>"",
+                        directory: ""<dir>""
+                    },
+                }")
+			}
+		});
+
+		IEnumerable<string> errors = Config.ReadConfig(fileSystem).Validate();
+		Assert.That(errors, Is.Empty, "a configuration with an Azure File Storage for upload should be valid");
+	}
+
+	[Test]
     public void MissingAttribute()
     {
         IFileSystem fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>()


### PR DESCRIPTION
Fixes VSTS #281194.

- [x] Tests written
- [x] Documentation updated

I've considered writing tests for the upload itself, but since this is essentially a thin layer over the .NET Azure library and we would have to mock the entire library (ourselves) to write tests, I don't think this is worth it.