### PR TITLE
Stacktrace

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -45,7 +45,8 @@ after_test:
   # robocopy sets weird exit codes (codes != 0 that still signal success) so we need to ignore them
   # c.f. https://superuser.com/questions/280425/getting-robocopy-to-return-a-proper-exit-code#346112
   # we achieve this by following up the robocopy commands with "exit 0"
-  - cmd: robocopy .\Profiler\bin\Release teamscale_dotnet_profiler *.dll & exit 0
+  - cmd: robocopy .\Profiler\bin\Release teamscale_dotnet_profiler *.dll *.pdb & exit 0
+  - cmd: robocopy . teamscale_dotnet_profiler LICENSE third_party.license & exit 0
   - cmd: robocopy .\UploadDaemon\bin\Release teamscale_dotnet_profiler\UploadDaemon *.* /xf *.pdb & exit 0
   - cmd: robocopy .\documentation teamscale_dotnet_profiler/Documentation userguide.pdf & exit 0
   - cmd: 7z a %release_zip% .\teamscale_dotnet_profiler

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -46,7 +46,7 @@ after_test:
   # c.f. https://superuser.com/questions/280425/getting-robocopy-to-return-a-proper-exit-code#346112
   # we achieve this by following up the robocopy commands with "exit 0"
   - cmd: robocopy .\Profiler\bin\Release teamscale_dotnet_profiler *.dll *.pdb & exit 0
-  - cmd: robocopy . teamscale_dotnet_profiler LICENSE third_party.license & exit 0
+  - cmd: robocopy . teamscale_dotnet_profiler LICENSE third-party.license & exit 0
   - cmd: robocopy .\UploadDaemon\bin\Release teamscale_dotnet_profiler\UploadDaemon *.* /xf *.pdb & exit 0
   - cmd: robocopy .\documentation teamscale_dotnet_profiler/Documentation userguide.pdf & exit 0
   - cmd: 7z a %release_zip% .\teamscale_dotnet_profiler

--- a/LICENSE
+++ b/LICENSE
@@ -173,29 +173,3 @@
       incurred by, or claims asserted against, such Contributor by reason
       of your accepting any such warranty or additional liability.
 
-   END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright [yyyy] [name of copyright owner]
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.

--- a/Profiler/CClassFactory.cpp
+++ b/Profiler/CClassFactory.cpp
@@ -1,11 +1,12 @@
 #include "CProfilerCallback.h"
 #include "CClassFactory.h"
+#include "Stacktrace.h"
 
 #define ARRAY_LENGTH(s) (sizeof(s) / sizeof(s[0]))
 
 BOOL WINAPI DllMain(HINSTANCE hInstance, DWORD dwReason, LPVOID lpReserved) {
-	// Save off the instance handle for later use.
 	if (dwReason == DLL_PROCESS_ATTACH) {
+		// Save off the instance handle for later use.
 		DisableThreadLibraryCalls(hInstance);
 		profilerInstance = hInstance;
 	}
@@ -27,11 +28,11 @@ STDAPI DllUnregisterServer() {
 
 	memset(szCLSID, 0, sizeof(szCLSID));
 	UnregisterClassBase(CLSID_PROFILER, rcProgID, rcIndProgID, szCLSID,
-	ARRAY_LENGTH(szCLSID));
+		ARRAY_LENGTH(szCLSID));
 
 	DeleteKey(szCLSID, inProcessServerDeclaration);
 
-	StringFromGUID2(CLSID_PROFILER, szWID, ARRAY_LENGTH( szWID ));
+	StringFromGUID2(CLSID_PROFILER, szWID, ARRAY_LENGTH(szWID));
 	WideCharToMultiByte(CP_ACP, 0, szWID, -1, szID, sizeof(szID), NULL, NULL);
 
 	DeleteKey("CLSID", szCLSID);
@@ -58,7 +59,7 @@ STDAPI DllRegisterServer() {
 
 	// Do the initial portion.
 	hr = RegisterClassBase(CLSID_PROFILER, "Profiler", rcProgID, rcIndProgID,
-			rcCLSID, ARRAY_LENGTH (rcCLSID));
+		rcCLSID, ARRAY_LENGTH(rcCLSID));
 
 	if (SUCCEEDED(hr)) {
 		// Set the server path.
@@ -66,9 +67,10 @@ STDAPI DllRegisterServer() {
 
 		// Add the threading model information.
 		sprintf_s(rcInproc, maxLength + 2, "%s\\%s", rcCLSID,
-				inProcessServerDeclaration);
+			inProcessServerDeclaration);
 		CreateRegistryKeyAndSetValue(rcInproc, "ThreadingModel", "Both");
-	} else {
+	}
+	else {
 		DllUnregisterServer();
 	}
 	return hr;
@@ -86,15 +88,17 @@ STDAPI DllGetClassObject(REFCLSID rclsid, REFIID riid, LPVOID FAR *ppv) {
 
 /** Implementation of the COM QueryInterface. */
 HRESULT CClassFactory::QueryInterface(REFIID riid, void **ppInterface) {
-	if (!ppInterface){
+	if (!ppInterface) {
 		return E_INVALIDARG;
 	}
 
 	if (riid == IID_IUnknown) {
 		*ppInterface = this;
-	} else if (riid == IID_IClassFactory) {
+	}
+	else if (riid == IID_IClassFactory) {
 		*ppInterface = this;
-	} else {
+	}
+	else {
 		*ppInterface = NULL;
 		return E_NOINTERFACE;
 	}
@@ -110,21 +114,21 @@ STDAPI DllCanUnloadNow(void) {
 
 /** Instantiates the Profiler (CProfilerCallback) */
 HRESULT CClassFactory::CreateInstance(IUnknown *pUnkOuter, REFIID riid,
-		void **ppInstance) {
+	void **ppInstance) {
 	// Aggregation is not supported by these objects.
 	if (pUnkOuter != NULL) {
 		return CLASS_E_NOAGGREGATION;
 	}
 
 	CProfilerCallback *pProfilerCallback = new CProfilerCallback();
-	*ppInstance = (void *) pProfilerCallback;
+	*ppInstance = (void *)pProfilerCallback;
 
 	return S_OK;
 }
 
 HRESULT RegisterClassBase(REFCLSID rclsid, const char *szDesc,
-		const char *szProgID, const char *szIndepProgID, char *szOutCLSID,
-		size_t nOutCLSIDLen) {
+	const char *szProgID, const char *szIndepProgID, char *szOutCLSID,
+	size_t nOutCLSIDLen) {
 	char szID[64];     // The class ID to register.
 
 	CreateIDs(rclsid, szOutCLSID, nOutCLSIDLen, szID);
@@ -144,18 +148,19 @@ HRESULT RegisterClassBase(REFCLSID rclsid, const char *szDesc,
 	success &= CreateFullKeyAndRegister(szOutCLSID, NULL, szDesc);
 	success &= CreateFullKeyAndRegister(szOutCLSID, "ProgID", szProgID);
 	success &= CreateFullKeyAndRegister(szOutCLSID, "VersionIndependentProgID",
-			szIndepProgID);
+		szIndepProgID);
 	success &= CreateFullKeyAndRegister(szOutCLSID, "NotInsertable", NULL);
 
 	if (success) {
 		return S_OK;
-	} else {
+	}
+	else {
 		return S_FALSE;
 	}
 }
 
 HRESULT UnregisterClassBase(REFCLSID rclsid, const char *szProgID,
-		const char *szIndepProgID, char *szOutCLSID, size_t nOutCLSIDLen) {
+	const char *szIndepProgID, char *szOutCLSID, size_t nOutCLSIDLen) {
 	char szID[64];     // The class ID to register.
 	CreateIDs(rclsid, szOutCLSID, nOutCLSIDLen, szID);
 
@@ -178,15 +183,16 @@ HRESULT UnregisterClassBase(REFCLSID rclsid, const char *szProgID,
 
 	if (success) {
 		return S_OK;
-	} else {
+	}
+	else {
 		return S_FALSE;
 	}
 }
 
-void CreateIDs(REFCLSID rclsid, char *szOutCLSID, size_t nOutCLSIDLen, char* szID){
+void CreateIDs(REFCLSID rclsid, char *szOutCLSID, size_t nOutCLSIDLen, char* szID) {
 	OLECHAR szWID[64]; // Helper for the class ID to register.
 
-	StringFromGUID2(rclsid, szWID, ARRAY_LENGTH( szWID ));
+	StringFromGUID2(rclsid, szWID, ARRAY_LENGTH(szWID));
 	WideCharToMultiByte(CP_ACP, 0, szWID, -1, szID, sizeof(szID), NULL, NULL);
 
 	strcpy_s(szOutCLSID, nOutCLSIDLen, "CLSID\\");
@@ -207,7 +213,7 @@ BOOL DeleteKey(const char *szKey, const char *szSubkey) {
 }
 
 BOOL CreateFullKeyAndRegister(const char *szKey, const char *szSubkey,
-		const char *szValue) {
+	const char *szValue) {
 	char rcKey[maxLength]; // Buffer for the full key name.
 
 	// Initialize the key with the base key name.
@@ -227,12 +233,12 @@ BOOL CreateRegistryKeyAndSetValue(const char *szKeyName, const char *szKeyword, 
 
 	// create the registration key.
 	if (RegCreateKeyExA(HKEY_CLASSES_ROOT, szKeyName, 0, NULL,
-			REG_OPTION_NON_VOLATILE, KEY_ALL_ACCESS, NULL, &hKey, NULL)
-			== ERROR_SUCCESS) {
+		REG_OPTION_NON_VOLATILE, KEY_ALL_ACCESS, NULL, &hKey, NULL)
+		== ERROR_SUCCESS) {
 		// set the value (if there is one).
 		if (szValue != NULL) {
-			RegSetValueExA(hKey, szKeyword, 0, REG_SZ, (BYTE *) szValue,
-					(DWORD)((strlen(szValue) + 1) * sizeof(char)));
+			RegSetValueExA(hKey, szKeyword, 0, REG_SZ, (BYTE *)szValue,
+				(DWORD)((strlen(szValue) + 1) * sizeof(char)));
 		}
 
 		RegCloseKey(hKey);

--- a/Profiler/CClassFactory.cpp
+++ b/Profiler/CClassFactory.cpp
@@ -1,6 +1,5 @@
 #include "CProfilerCallback.h"
 #include "CClassFactory.h"
-#include "Stacktrace.h"
 
 #define ARRAY_LENGTH(s) (sizeof(s) / sizeof(s[0]))
 

--- a/Profiler/CProfilerCallback.cpp
+++ b/Profiler/CProfilerCallback.cpp
@@ -237,8 +237,6 @@ UINT_PTR CProfilerCallback::functionMapper(FunctionID functionId, BOOL* pbHookFu
 
 HRESULT CProfilerCallback::AssemblyLoadFinished(AssemblyID assemblyId, HRESULT hrStatus) {
 	try {
-		char *p = 0;
-		p[12] = 42;
 		return AssemblyLoadFinishedImplementation(assemblyId, hrStatus);
 	}
 	catch (...) {

--- a/Profiler/CProfilerCallback.cpp
+++ b/Profiler/CProfilerCallback.cpp
@@ -141,7 +141,6 @@ void CProfilerCallback::readConfig() {
 	log.info("looking for configuration options in: " + configFile);
 
 	std::ifstream inputStream(configFile);
-	this->configOptions = std::map<std::string, std::string>();
 	for (std::string line; getline(inputStream, line);) {
 		size_t delimiterPosition = line.find("=");
 		if (delimiterPosition == std::string::npos) {

--- a/Profiler/CProfilerCallback.cpp
+++ b/Profiler/CProfilerCallback.cpp
@@ -221,13 +221,19 @@ DWORD CProfilerCallback::getEventMask() {
 	return dwEventMask;
 }
 
-UINT_PTR CProfilerCallback::functionMapper(FunctionID functionId,
-	BOOL* pbHookFunction) {
-	// Disable hooking of functions.
-	*pbHookFunction = false;
+UINT_PTR CProfilerCallback::functionMapper(FunctionID functionId, BOOL* pbHookFunction) {
+	try {
+		// Disable hooking of functions.
+		*pbHookFunction = false;
 
-	// Always return original function id.
-	return functionId;
+		// Always return original function id.
+		return functionId;
+	}
+	catch (...) {
+		Debug::logStacktrace("functionMapper");
+		// since this function must be static, we have no way to call getOption() so we always terminate the program.
+		throw;
+	}
 }
 
 HRESULT CProfilerCallback::AssemblyLoadFinished(AssemblyID assemblyId, HRESULT hrStatus) {

--- a/Profiler/CProfilerCallback.cpp
+++ b/Profiler/CProfilerCallback.cpp
@@ -6,8 +6,7 @@
 #include <fstream>
 #include <algorithm>
 #include <winuser.h>
-
-using namespace std;
+#include "Debug.h"
 
 #pragma comment(lib, "version.lib")
 #pragma intrinsic(strcmp,labs,strcpy,_rotl,memcmp,strlen,_rotr,memcpy,_lrotl,_strset,memset,_lrotr,abs,strcat)
@@ -54,6 +53,7 @@ HRESULT CProfilerCallback::Initialize(IUnknown* pICorProfilerInfoUnkown) {
 	log.info("Eagerness: " + std::to_string(eagerness));
 
 	if (getOption("UPLOAD_DAEMON") == "1") {
+		log.info("Starting upload deamon");
 		startUploadDeamon();
 	}
 
@@ -283,15 +283,23 @@ void CProfilerCallback::getAssemblyInfo(AssemblyID assemblyId, WCHAR *assemblyNa
 
 HRESULT CProfilerCallback::JITCompilationFinished(FunctionID functionId,
 	HRESULT hrStatus, BOOL fIsSafeToBlock) {
-	if (isProfilingEnabled) {
-		EnterCriticalSection(&callbackSynchronization);
+	try {
+		if (isProfilingEnabled) {
+			EnterCriticalSection(&callbackSynchronization);
 
-		recordFunctionInfo(&jittedMethods, functionId);
+			recordFunctionInfo(&jittedMethods, functionId);
 
-		LeaveCriticalSection(&callbackSynchronization);
+			LeaveCriticalSection(&callbackSynchronization);
+		}
+		Debug::log("npe2\r\n");
+		char* ptr = (char*)0xBADC0DE;
+		ptr[42] = 0;
+		return S_OK;
 	}
-
-	return S_OK;
+	catch (...) {
+		Debug::logStacktrace();
+		throw;
+	}
 }
 
 HRESULT CProfilerCallback::JITInlining(FunctionID callerID, FunctionID calleeId,

--- a/Profiler/CProfilerCallback.cpp
+++ b/Profiler/CProfilerCallback.cpp
@@ -16,9 +16,7 @@ CProfilerCallback::CProfilerCallback() {
 		InitializeCriticalSection(&callbackSynchronization);
 	}
 	catch (...) {
-		if (!handleException("Constructor")) {
-			throw;
-		}
+		handleException("Constructor");
 	}
 }
 
@@ -27,9 +25,7 @@ CProfilerCallback::~CProfilerCallback() {
 		DeleteCriticalSection(&callbackSynchronization);
 	}
 	catch (...) {
-		if (!handleException("Destructor")) {
-			throw;
-		}
+		handleException("Destructor");
 	}
 }
 
@@ -38,10 +34,7 @@ HRESULT CProfilerCallback::Initialize(IUnknown* pICorProfilerInfoUnkown) {
 		return InitializeImplementation(pICorProfilerInfoUnkown);
 	}
 	catch (...) {
-		if (handleException("Initialize")) {
-			return S_OK;
-		}
-		throw;
+		handleException("Initialize");
 	}
 }
 
@@ -200,10 +193,8 @@ HRESULT CProfilerCallback::Shutdown() {
 		return ShutdownImplementation();
 	}
 	catch (...) {
-		if (handleException("Shutdown")) {
-			return S_OK;
-		}
-		throw;
+		handleException("Shutdown");
+		return S_OK;
 	}
 }
 
@@ -240,10 +231,8 @@ HRESULT CProfilerCallback::AssemblyLoadFinished(AssemblyID assemblyId, HRESULT h
 		return AssemblyLoadFinishedImplementation(assemblyId, hrStatus);
 	}
 	catch (...) {
-		if (handleException("AssemblyLoadFinished")) {
-			return S_OK;
-		}
-		throw;
+		handleException("AssemblyLoadFinished");
+		return S_OK;
 	}
 }
 
@@ -342,21 +331,16 @@ HRESULT CProfilerCallback::JITCompilationFinished(FunctionID functionId,
 		return JITCompilationFinishedImplementation(functionId, hrStatus, fIsSafeToBlock);
 	}
 	catch (...) {
-		if (handleException("JITCompilationFinished")) {
-			return S_OK;
-		}
-		throw;
+		handleException("JITCompilationFinished");
+		return S_OK;
 	}
 }
 
-bool CProfilerCallback::handleException(std::string context) {
+void CProfilerCallback::handleException(std::string context) {
 	Debug::logStacktrace(context);
-	if (getOption("IGNORE_EXCEPTIONS") == "1") {
-		// swallows the exception
-		return true;
+	if (getOption("IGNORE_EXCEPTIONS") != "1") {
+		throw;
 	}
-	// forwards the exception, i.e. crashes the program
-	return false;
 }
 
 HRESULT CProfilerCallback::JITCompilationFinishedImplementation(FunctionID functionId,
@@ -377,10 +361,8 @@ HRESULT CProfilerCallback::JITInlining(FunctionID callerId, FunctionID calleeId,
 		return JITInliningImplementation(callerId, calleeId, pfShouldInline);
 	}
 	catch (...) {
-		if (handleException("JITInlining")) {
-			return S_OK;
-		}
-		throw;
+		handleException("JITInlining");
+		return S_OK;
 	}
 }
 

--- a/Profiler/CProfilerCallback.h
+++ b/Profiler/CProfilerCallback.h
@@ -166,6 +166,6 @@ private:
 	HRESULT JITInliningImplementation(FunctionID callerID, FunctionID calleeID, BOOL *pfShouldInline);
 	HRESULT InitializeImplementation(IUnknown *pICorProfilerInfoUnk);
 
-	/** Logs a stack trace. If true is returned, the calling code should continue, otherwise it should rethrow the exception. */
-	bool handleException(std::string context);
+	/** Logs a stack trace. May rethrow the caught exception. */
+	void handleException(std::string context);
 };

--- a/Profiler/CProfilerCallback.h
+++ b/Profiler/CProfilerCallback.h
@@ -85,7 +85,7 @@ private:
 	/**
 	* Stores all declared options from the config file.
 	*/
-	std::map<std::string, std::string> configOptions;
+	std::map<std::string, std::string> configOptions = std::map<std::string, std::string>();
 
 	/** Smart pointer to the .NET framework profiler info. */
 	CComQIPtr<ICorProfilerInfo2> profilerInfo;

--- a/Profiler/CProfilerCallback.h
+++ b/Profiler/CProfilerCallback.h
@@ -160,4 +160,8 @@ private:
 
 	/** Writes the fileVersionInfo into the provided buffer. */
 	int writeFileVersionInfo(LPCWSTR moduleFileName, char* buffer, size_t bufferSize);
+
+	HRESULT JITCompilationFinishedImplementation(FunctionID functionID);
+
+	int CProfilerCallback::handleException(std::string context, struct _EXCEPTION_POINTERS *exceptionPointers);
 };

--- a/Profiler/CProfilerCallback.h
+++ b/Profiler/CProfilerCallback.h
@@ -163,5 +163,5 @@ private:
 
 	HRESULT JITCompilationFinishedImplementation(FunctionID functionID);
 
-	int CProfilerCallback::handleException(std::string context, struct _EXCEPTION_POINTERS *exceptionPointers);
+	bool CProfilerCallback::handleException(std::string context);
 };

--- a/Profiler/CProfilerCallback.h
+++ b/Profiler/CProfilerCallback.h
@@ -119,8 +119,7 @@ private:
 	* enabled in the event mask in order to force JIT-events for each first call to
 	* a function, independent of whether a pre-jitted version exists.)
 	*/
-	static UINT_PTR _stdcall functionMapper(FunctionID functionId,
-		BOOL *pbHookFunction);
+	static UINT_PTR _stdcall functionMapper(FunctionID functionId, BOOL *pbHookFunction) throw(...);
 
 	/** Dumps all environment variables to the log file. */
 	void dumpEnvironment();

--- a/Profiler/CProfilerCallbackBase.h
+++ b/Profiler/CProfilerCallbackBase.h
@@ -11,23 +11,21 @@
  * The callbacks the profiler needs are implemented (overridden) in the subclass.
 */
 class CProfilerCallbackBase : public ICorProfilerCallback3 {
-
 public:
 	/** Constructor */
 	CProfilerCallbackBase();
 
 	/** Destructor */
-	virtual ~CProfilerCallbackBase(){ /* nothing to do. */};
+	virtual ~CProfilerCallbackBase() throw(...) { /* nothing to do. */ };
 
-// IUnknown interface implementation
+	// IUnknown interface implementation
 	STDMETHOD_(ULONG, AddRef)();
 	STDMETHOD_(ULONG, Release)();
-	STDMETHOD(QueryInterface)( REFIID riid, void **ppInterface );           
-// End of IUnknown interface implementation
+	STDMETHOD(QueryInterface)(REFIID riid, void **ppInterface);
+	// End of IUnknown interface implementation
 
-
-// ICorProfilerCallback interface implementation
-	// STARTUP/SHUTDOWN EVENTS
+	// ICorProfilerCallback interface implementation
+		// STARTUP/SHUTDOWN EVENTS
 	STDMETHOD(Initialize)(IUnknown *pICorProfilerInfoUnk);
 	STDMETHOD(Shutdown)();
 	// APPLICATION DOMAIN EVENTS
@@ -114,9 +112,9 @@ public:
 	// COM CLASSIC VTable
 	STDMETHOD(COMClassicVTableCreated)(ClassID wrappedClassID, REFGUID implementedIID, void *pVTable, ULONG cSlots);
 	STDMETHOD(COMClassicVTableDestroyed)(ClassID wrappedClassID, REFGUID implementedIID, void *pVTable);
-// End of ICorProfilerCallback interface implementation
+	// End of ICorProfilerCallback interface implementation
 
-// ICorProfilerCallback2 interface implementation
+	// ICorProfilerCallback2 interface implementation
 	STDMETHOD(ThreadNameChanged)(ThreadID threadId, ULONG cchName, WCHAR name[]);
 	STDMETHOD(GarbageCollectionStarted)(int cGenerations, BOOL generationCollected[], COR_PRF_GC_REASON reason);
 	STDMETHOD(SurvivingReferences)(ULONG cSurvivingObjectIDRanges, ObjectID objectIDRangeStart[], ULONG cObjectIDRangeLength[]);
@@ -125,16 +123,15 @@ public:
 	STDMETHOD(RootReferences2)(ULONG cRootRefs, ObjectID rootRefIds[], COR_PRF_GC_ROOT_KIND rootKinds[], COR_PRF_GC_ROOT_FLAGS rootFlags[], UINT_PTR rootIds[]);
 	STDMETHOD(HandleCreated)(GCHandleID handleId, ObjectID initialObjectId);
 	STDMETHOD(HandleDestroyed)(GCHandleID handleId);
-// End of ICorProfilerCallback2 interface implementation
+	// End of ICorProfilerCallback2 interface implementation
 
-// ICorProfilerCallback3 interface implementation
-	STDMETHOD(InitializeForAttach)(IUnknown * pCorProfilerInfoUnk,void * pvClientData, UINT cbClientData);
+	// ICorProfilerCallback3 interface implementation
+	STDMETHOD(InitializeForAttach)(IUnknown * pCorProfilerInfoUnk, void * pvClientData, UINT cbClientData);
 	STDMETHOD(ProfilerAttachComplete)();
 	STDMETHOD(ProfilerDetachSucceeded)();
-// End of ICorProfilerCallback3 interface implementation
+	// End of ICorProfilerCallback3 interface implementation
 
 private:
 	// COM reference counter (for AddRef() and Release()) of the IUnknown implementation of the profiler
-	long referenceCount; 
-
+	long referenceCount;
 };

--- a/Profiler/Debug.cpp
+++ b/Profiler/Debug.cpp
@@ -1,12 +1,5 @@
 #include "Debug.h"
 #include "StackWalker.h"
-#include <DbgHelp.h>
-
-typedef BOOL(WINAPI *MINIDUMPWRITEDUMP)(HANDLE hProcess, DWORD dwPid, HANDLE hFile, MINIDUMP_TYPE DumpType,
-	CONST PMINIDUMP_EXCEPTION_INFORMATION ExceptionParam,
-	CONST PMINIDUMP_USER_STREAM_INFORMATION UserStreamParam,
-	CONST PMINIDUMP_CALLBACK_INFORMATION CallbackParam
-	);
 
 class CustomStackWalker : public StackWalker {
 public:

--- a/Profiler/Debug.cpp
+++ b/Profiler/Debug.cpp
@@ -39,51 +39,9 @@ void Debug::logInternal(std::string message)
 	WriteFile(logFile, message.c_str(), (DWORD)strlen(message.c_str()), NULL, NULL);
 }
 
-void Debug::logStacktraceAndCreateMinidump(std::string context, struct _EXCEPTION_POINTERS *exceptionPointers) {
+void Debug::logStacktrace(std::string context) {
 	log("Stacktrace: " + context);
 	CustomStackWalker stackWalker;
 	stackWalker.ShowCallstack();
 	log(stackWalker.output);
-	writeMinidump(exceptionPointers);
-}
-
-void Debug::writeMinidump(struct _EXCEPTION_POINTERS *exceptionPointers)
-{
-	HMODULE dllHandle = LoadLibrary("DBGHELP.DLL");
-	LPCTSTR szResult = NULL;
-
-	if (!dllHandle)
-	{
-		Debug::log("Couldn't find dbghelp.dll\n");
-		return;
-	}
-
-	MINIDUMPWRITEDUMP dumpFunction = (MINIDUMPWRITEDUMP)::GetProcAddress(dllHandle, "MiniDumpWriteDump");
-	if (!dumpFunction)
-	{
-		Debug::log("Couldn't find MiniDumpWriteDump function\n");
-		return;
-	}
-
-	HANDLE hFile = CreateFile("C:\\Users\\Public\\profiler.minidump", GENERIC_WRITE, FILE_SHARE_READ, NULL, CREATE_ALWAYS,
-		FILE_ATTRIBUTE_NORMAL, NULL);
-	if (hFile == INVALID_HANDLE_VALUE)
-	{
-		Debug::log("Couldn't create minidump file\n");
-		return;
-	}
-
-	_MINIDUMP_EXCEPTION_INFORMATION exceptionInfo;
-
-	exceptionInfo.ThreadId = GetCurrentThreadId();
-	exceptionInfo.ExceptionPointers = exceptionPointers;
-	exceptionInfo.ClientPointers = NULL;
-
-	BOOL dumpSucceeded = dumpFunction(GetCurrentProcess(), GetCurrentProcessId(), hFile, (MINIDUMP_TYPE)(MiniDumpNormal | MiniDumpWithDataSegs), &exceptionInfo, NULL, NULL);
-	if (!dumpSucceeded)
-	{
-		Debug::log("Failed to write minidump file\n");
-	}
-
-	CloseHandle(hFile);
 }

--- a/Profiler/Debug.cpp
+++ b/Profiler/Debug.cpp
@@ -1,4 +1,14 @@
 #include "Debug.h"
+#include "StackWalker.h"
+
+class CustomStackWalker : public StackWalker {
+public:
+	std::string output;
+	void OnOutput(LPCSTR szText) {
+		output += szText;
+		output += "\r\n";
+	}
+};
 
 void Debug::log(std::string message)
 {
@@ -14,9 +24,17 @@ Debug::~Debug()
 
 void Debug::logInternal(std::string message)
 {
+	message += "\r\n";
 	if (logFile == INVALID_HANDLE_VALUE) {
 		logFile = CreateFile("C:\\Users\\Public\\profiler_debug.log", GENERIC_WRITE, FILE_SHARE_READ,
 			NULL, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
 	}
 	WriteFile(logFile, message.c_str(), (DWORD)strlen(message.c_str()), NULL, NULL);
+}
+
+void Debug::logStacktrace() {
+	log("Stacktrace:");
+	CustomStackWalker stackWalker;
+	stackWalker.ShowCallstack();
+	log(stackWalker.output);
 }

--- a/Profiler/Debug.cpp
+++ b/Profiler/Debug.cpp
@@ -1,5 +1,12 @@
 #include "Debug.h"
 #include "StackWalker.h"
+#include <DbgHelp.h>
+
+typedef BOOL(WINAPI *MINIDUMPWRITEDUMP)(HANDLE hProcess, DWORD dwPid, HANDLE hFile, MINIDUMP_TYPE DumpType,
+	CONST PMINIDUMP_EXCEPTION_INFORMATION ExceptionParam,
+	CONST PMINIDUMP_USER_STREAM_INFORMATION UserStreamParam,
+	CONST PMINIDUMP_CALLBACK_INFORMATION CallbackParam
+	);
 
 class CustomStackWalker : public StackWalker {
 public:
@@ -32,9 +39,51 @@ void Debug::logInternal(std::string message)
 	WriteFile(logFile, message.c_str(), (DWORD)strlen(message.c_str()), NULL, NULL);
 }
 
-void Debug::logStacktrace() {
-	log("Stacktrace:");
+void Debug::logStacktraceAndCreateMinidump(std::string context, struct _EXCEPTION_POINTERS *exceptionPointers) {
+	log("Stacktrace: " + context);
 	CustomStackWalker stackWalker;
 	stackWalker.ShowCallstack();
 	log(stackWalker.output);
+	writeMinidump(exceptionPointers);
+}
+
+void Debug::writeMinidump(struct _EXCEPTION_POINTERS *exceptionPointers)
+{
+	HMODULE dllHandle = LoadLibrary("DBGHELP.DLL");
+	LPCTSTR szResult = NULL;
+
+	if (!dllHandle)
+	{
+		Debug::log("Couldn't find dbghelp.dll\n");
+		return;
+	}
+
+	MINIDUMPWRITEDUMP dumpFunction = (MINIDUMPWRITEDUMP)::GetProcAddress(dllHandle, "MiniDumpWriteDump");
+	if (!dumpFunction)
+	{
+		Debug::log("Couldn't find MiniDumpWriteDump function\n");
+		return;
+	}
+
+	HANDLE hFile = CreateFile("C:\\Users\\Public\\profiler.minidump", GENERIC_WRITE, FILE_SHARE_READ, NULL, CREATE_ALWAYS,
+		FILE_ATTRIBUTE_NORMAL, NULL);
+	if (hFile == INVALID_HANDLE_VALUE)
+	{
+		Debug::log("Couldn't create minidump file\n");
+		return;
+	}
+
+	_MINIDUMP_EXCEPTION_INFORMATION exceptionInfo;
+
+	exceptionInfo.ThreadId = GetCurrentThreadId();
+	exceptionInfo.ExceptionPointers = exceptionPointers;
+	exceptionInfo.ClientPointers = NULL;
+
+	BOOL dumpSucceeded = dumpFunction(GetCurrentProcess(), GetCurrentProcessId(), hFile, (MINIDUMP_TYPE)(MiniDumpNormal | MiniDumpWithDataSegs), &exceptionInfo, NULL, NULL);
+	if (!dumpSucceeded)
+	{
+		Debug::log("Failed to write minidump file\n");
+	}
+
+	CloseHandle(hFile);
 }

--- a/Profiler/Debug.h
+++ b/Profiler/Debug.h
@@ -12,6 +12,9 @@ public:
 	/** Logs the given message to the debug log. */
 	static void log(std::string message);
 
+	/** Logs the current stack trace. */
+	static void logStacktrace();
+
 	virtual ~Debug();
 
 private:

--- a/Profiler/Debug.h
+++ b/Profiler/Debug.h
@@ -18,6 +18,8 @@ public:
 	virtual ~Debug();
 
 private:
+	Debug();
+
 	void logInternal(std::string message);
 
 	/**
@@ -34,4 +36,5 @@ private:
 	}
 
 	HANDLE logFile = INVALID_HANDLE_VALUE;
+	CRITICAL_SECTION loggingSynchronization;
 };

--- a/Profiler/Debug.h
+++ b/Profiler/Debug.h
@@ -13,7 +13,7 @@ public:
 	static void log(std::string message);
 
 	/** Logs the current stack trace. */
-	static void logStacktrace();
+	static void logStacktrace(std::string context);
 
 	virtual ~Debug();
 

--- a/Profiler/Profiler.vcxproj
+++ b/Profiler/Profiler.vcxproj
@@ -199,7 +199,6 @@
     <ClCompile Include="CProfilerCallback.cpp" />
     <ClCompile Include="Debug.cpp" />
     <ClCompile Include="Log.cpp" />
-    <ClCompile Include="Stacktrace.cpp" />
     <ClCompile Include="StackWalker.cpp" />
     <ClCompile Include="UploadDaemon.cpp" />
   </ItemGroup>
@@ -207,7 +206,6 @@
     <ClInclude Include="CClassFactory.h" />
     <ClInclude Include="CProfilerCallbackBase.h" />
     <ClCompile Include="StringUtils.cpp" />
-    <ClInclude Include="Stacktrace.h" />
     <ClInclude Include="StackWalker.h" />
     <ClInclude Include="StringUtils.h" />
     <ClInclude Include="Debug.h" />

--- a/Profiler/Profiler.vcxproj
+++ b/Profiler/Profiler.vcxproj
@@ -90,7 +90,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;Profiler_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
-      <ExceptionHandling>Sync</ExceptionHandling>
+      <ExceptionHandling>Async</ExceptionHandling>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <PrecompiledHeader>
@@ -113,7 +113,7 @@
     <ClCompile>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;Profiler_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <ExceptionHandling>Sync</ExceptionHandling>
+      <ExceptionHandling>Async</ExceptionHandling>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <PrecompiledHeader>
@@ -146,6 +146,7 @@
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <LanguageStandard>
       </LanguageStandard>
+      <ExceptionHandling>Async</ExceptionHandling>
     </ClCompile>
     <Link>
       <AdditionalDependencies>corguids.lib;version.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -176,6 +177,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <ExceptionHandling>Async</ExceptionHandling>
     </ClCompile>
     <Link>
       <AdditionalDependencies>corguids.lib;version.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -197,12 +199,16 @@
     <ClCompile Include="CProfilerCallback.cpp" />
     <ClCompile Include="Debug.cpp" />
     <ClCompile Include="Log.cpp" />
+    <ClCompile Include="Stacktrace.cpp" />
+    <ClCompile Include="StackWalker.cpp" />
     <ClCompile Include="UploadDaemon.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="CClassFactory.h" />
     <ClInclude Include="CProfilerCallbackBase.h" />
     <ClCompile Include="StringUtils.cpp" />
+    <ClInclude Include="Stacktrace.h" />
+    <ClInclude Include="StackWalker.h" />
     <ClInclude Include="StringUtils.h" />
     <ClInclude Include="Debug.h" />
     <ClInclude Include="FunctionInfo.h" />

--- a/Profiler/Profiler.vcxproj.filters
+++ b/Profiler/Profiler.vcxproj.filters
@@ -39,9 +39,6 @@
     <ClCompile Include="Debug.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="Stacktrace.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="StackWalker.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -78,9 +75,6 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="Debug.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="Stacktrace.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="StackWalker.h">

--- a/Profiler/Profiler.vcxproj.filters
+++ b/Profiler/Profiler.vcxproj.filters
@@ -39,6 +39,12 @@
     <ClCompile Include="Debug.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="Stacktrace.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="StackWalker.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="CProfilerCallbackBase.h">
@@ -72,6 +78,12 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="Debug.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Stacktrace.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="StackWalker.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/Profiler/StackWalker.cpp
+++ b/Profiler/StackWalker.cpp
@@ -1,0 +1,1220 @@
+/**********************************************************************
+ * 
+ * StackWalker.cpp
+ *
+ *
+ * History:
+ *  2005-07-27   v1    - First public release on http://www.codeproject.com/
+ *                       http://www.codeproject.com/threads/StackWalker.asp
+ *  2005-07-28   v2    - Changed the params of the constructor and ShowCallstack
+ *                       (to simplify the usage)
+ *  2005-08-01   v3    - Changed to use 'CONTEXT_FULL' instead of CONTEXT_ALL 
+ *                       (should also be enough)
+ *                     - Changed to compile correctly with the PSDK of VC7.0
+ *                       (GetFileVersionInfoSizeA and GetFileVersionInfoA is wrongly defined:
+ *                        it uses LPSTR instead of LPCSTR as first paremeter)
+ *                     - Added declarations to support VC5/6 without using 'dbghelp.h'
+ *                     - Added a 'pUserData' member to the ShowCallstack function and the 
+ *                       PReadProcessMemoryRoutine declaration (to pass some user-defined data, 
+ *                       which can be used in the readMemoryFunction-callback)
+ *  2005-08-02   v4    - OnSymInit now also outputs the OS-Version by default
+ *                     - Added example for doing an exception-callstack-walking in main.cpp
+ *                       (thanks to owillebo: http://www.codeproject.com/script/profile/whos_who.asp?id=536268)
+ *  2005-08-05   v5    - Removed most Lint (http://www.gimpel.com/) errors... thanks to Okko Willeboordse!
+ *
+ **********************************************************************/
+#include <windows.h>
+#include <tchar.h>
+#include <stdio.h>
+#pragma comment(lib, "version.lib")  // for "VerQueryValue"
+
+#include "StackWalker.h"
+
+
+// If VC7 and later, then use the shipped 'dbghelp.h'-file
+#if _MSC_VER >= 1300
+#include <dbghelp.h>
+#else
+// inline the important dbghelp.h-declarations...
+typedef enum {
+    SymNone = 0,
+    SymCoff,
+    SymCv,
+    SymPdb,
+    SymExport,
+    SymDeferred,
+    SymSym,
+    SymDia,
+    SymVirtual,
+    NumSymTypes
+} SYM_TYPE;
+typedef struct _IMAGEHLP_LINE64 {
+    DWORD                       SizeOfStruct;           // set to sizeof(IMAGEHLP_LINE64)
+    PVOID                       Key;                    // internal
+    DWORD                       LineNumber;             // line number in file
+    PCHAR                       FileName;               // full filename
+    DWORD64                     Address;                // first instruction of line
+} IMAGEHLP_LINE64, *PIMAGEHLP_LINE64;
+typedef struct _IMAGEHLP_MODULE64 {
+    DWORD                       SizeOfStruct;           // set to sizeof(IMAGEHLP_MODULE64)
+    DWORD64                     BaseOfImage;            // base load address of module
+    DWORD                       ImageSize;              // virtual size of the loaded module
+    DWORD                       TimeDateStamp;          // date/time stamp from pe header
+    DWORD                       CheckSum;               // checksum from the pe header
+    DWORD                       NumSyms;                // number of symbols in the symbol table
+    SYM_TYPE                    SymType;                // type of symbols loaded
+    CHAR                        ModuleName[32];         // module name
+    CHAR                        ImageName[256];         // image name
+    CHAR                        LoadedImageName[256];   // symbol file name
+} IMAGEHLP_MODULE64, *PIMAGEHLP_MODULE64;
+typedef struct _IMAGEHLP_SYMBOL64 {
+    DWORD                       SizeOfStruct;           // set to sizeof(IMAGEHLP_SYMBOL64)
+    DWORD64                     Address;                // virtual address including dll base address
+    DWORD                       Size;                   // estimated size of symbol, can be zero
+    DWORD                       Flags;                  // info about the symbols, see the SYMF defines
+    DWORD                       MaxNameLength;          // maximum size of symbol name in 'Name'
+    CHAR                        Name[1];                // symbol name (null terminated string)
+} IMAGEHLP_SYMBOL64, *PIMAGEHLP_SYMBOL64;
+typedef enum {
+    AddrMode1616,
+    AddrMode1632,
+    AddrModeReal,
+    AddrModeFlat
+} ADDRESS_MODE;
+typedef struct _tagADDRESS64 {
+    DWORD64       Offset;
+    WORD          Segment;
+    ADDRESS_MODE  Mode;
+} ADDRESS64, *LPADDRESS64;
+typedef struct _KDHELP64 {
+    DWORD64   Thread;
+    DWORD   ThCallbackStack;
+    DWORD   ThCallbackBStore;
+    DWORD   NextCallback;
+    DWORD   FramePointer;
+    DWORD64   KiCallUserMode;
+    DWORD64   KeUserCallbackDispatcher;
+    DWORD64   SystemRangeStart;
+    DWORD64  Reserved[8];
+} KDHELP64, *PKDHELP64;
+typedef struct _tagSTACKFRAME64 {
+    ADDRESS64   AddrPC;               // program counter
+    ADDRESS64   AddrReturn;           // return address
+    ADDRESS64   AddrFrame;            // frame pointer
+    ADDRESS64   AddrStack;            // stack pointer
+    ADDRESS64   AddrBStore;           // backing store pointer
+    PVOID       FuncTableEntry;       // pointer to pdata/fpo or NULL
+    DWORD64     Params[4];            // possible arguments to the function
+    BOOL        Far;                  // WOW far call
+    BOOL        Virtual;              // is this a virtual frame?
+    DWORD64     Reserved[3];
+    KDHELP64    KdHelp;
+} STACKFRAME64, *LPSTACKFRAME64;
+typedef
+BOOL
+(__stdcall *PREAD_PROCESS_MEMORY_ROUTINE64)(
+    HANDLE      hProcess,
+    DWORD64     qwBaseAddress,
+    PVOID       lpBuffer,
+    DWORD       nSize,
+    LPDWORD     lpNumberOfBytesRead
+    );
+typedef
+PVOID
+(__stdcall *PFUNCTION_TABLE_ACCESS_ROUTINE64)(
+    HANDLE  hProcess,
+    DWORD64 AddrBase
+    );
+typedef
+DWORD64
+(__stdcall *PGET_MODULE_BASE_ROUTINE64)(
+    HANDLE  hProcess,
+    DWORD64 Address
+    );
+typedef
+DWORD64
+(__stdcall *PTRANSLATE_ADDRESS_ROUTINE64)(
+    HANDLE    hProcess,
+    HANDLE    hThread,
+    LPADDRESS64 lpaddr
+    );
+#define SYMOPT_CASE_INSENSITIVE         0x00000001
+#define SYMOPT_UNDNAME                  0x00000002
+#define SYMOPT_DEFERRED_LOADS           0x00000004
+#define SYMOPT_NO_CPP                   0x00000008
+#define SYMOPT_LOAD_LINES               0x00000010
+#define SYMOPT_OMAP_FIND_NEAREST        0x00000020
+#define SYMOPT_LOAD_ANYTHING            0x00000040
+#define SYMOPT_IGNORE_CVREC             0x00000080
+#define SYMOPT_NO_UNQUALIFIED_LOADS     0x00000100
+#define SYMOPT_FAIL_CRITICAL_ERRORS     0x00000200
+#define SYMOPT_EXACT_SYMBOLS            0x00000400
+#define SYMOPT_ALLOW_ABSOLUTE_SYMBOLS   0x00000800
+#define SYMOPT_IGNORE_NT_SYMPATH        0x00001000
+#define SYMOPT_INCLUDE_32BIT_MODULES    0x00002000
+#define SYMOPT_PUBLICS_ONLY             0x00004000
+#define SYMOPT_NO_PUBLICS               0x00008000
+#define SYMOPT_AUTO_PUBLICS             0x00010000
+#define SYMOPT_NO_IMAGE_SEARCH          0x00020000
+#define SYMOPT_SECURE                   0x00040000
+#define SYMOPT_DEBUG                    0x80000000
+#define UNDNAME_COMPLETE                 (0x0000)  // Enable full undecoration
+#define UNDNAME_NAME_ONLY                (0x1000)  // Crack only the name for primary declaration;
+#endif  // _MSC_VER < 1300
+
+// Some missing defines (for VC5/6):
+#ifndef INVALID_FILE_ATTRIBUTES
+#define INVALID_FILE_ATTRIBUTES ((DWORD)-1)
+#endif  
+
+
+// secure-CRT_functions are only available starting with VC8
+#if _MSC_VER < 1400
+#define strcpy_s strcpy
+#define strcat_s(dst, len, src) strcat(dst, src)
+#define _snprintf_s _snprintf
+#define _tcscat_s _tcscat
+#endif
+
+// Normally it should be enough to use 'CONTEXT_FULL' (better would be 'CONTEXT_ALL')
+#define USED_CONTEXT_FLAGS CONTEXT_FULL
+
+
+class StackWalkerInternal
+{
+public:
+  StackWalkerInternal(StackWalker *parent, HANDLE hProcess)
+  {
+    m_parent = parent;
+    m_hDbhHelp = NULL;
+    pSC = NULL;
+    m_hProcess = hProcess;
+    m_szSymPath = NULL;
+    pSFTA = NULL;
+    pSGLFA = NULL;
+    pSGMB = NULL;
+    pSGMI = NULL;
+    pSGO = NULL;
+    pSGSFA = NULL;
+    pSI = NULL;
+    pSLM = NULL;
+    pSSO = NULL;
+    pSW = NULL;
+    pUDSN = NULL;
+    pSGSP = NULL;
+  }
+  ~StackWalkerInternal()
+  {
+    if (pSC != NULL)
+      pSC(m_hProcess);  // SymCleanup
+    if (m_hDbhHelp != NULL)
+      FreeLibrary(m_hDbhHelp);
+    m_hDbhHelp = NULL;
+    m_parent = NULL;
+    if(m_szSymPath != NULL)
+      free(m_szSymPath);
+    m_szSymPath = NULL;
+  }
+  BOOL Init(LPCSTR szSymPath)
+  {
+    if (m_parent == NULL)
+      return FALSE;
+    // Dynamically load the Entry-Points for dbghelp.dll:
+    // First try to load the newsest one from
+    TCHAR szTemp[4096];
+    // But before wqe do this, we first check if the ".local" file exists
+    if (GetModuleFileName(NULL, szTemp, 4096) > 0)
+    {
+      _tcscat_s(szTemp, _T(".local"));
+      if (GetFileAttributes(szTemp) == INVALID_FILE_ATTRIBUTES)
+      {
+        // ".local" file does not exist, so we can try to load the dbghelp.dll from the "Debugging Tools for Windows"
+        if (GetEnvironmentVariable(_T("ProgramFiles"), szTemp, 4096) > 0)
+        {
+          _tcscat_s(szTemp, _T("\\Debugging Tools for Windows\\dbghelp.dll"));
+          // now check if the file exists:
+          if (GetFileAttributes(szTemp) != INVALID_FILE_ATTRIBUTES)
+          {
+            m_hDbhHelp = LoadLibrary(szTemp);
+          }
+        }
+          // Still not found? Then try to load the 64-Bit version:
+        if ( (m_hDbhHelp == NULL) && (GetEnvironmentVariable(_T("ProgramFiles"), szTemp, 4096) > 0) )
+        {
+          _tcscat_s(szTemp, _T("\\Debugging Tools for Windows 64-Bit\\dbghelp.dll"));
+          if (GetFileAttributes(szTemp) != INVALID_FILE_ATTRIBUTES)
+          {
+            m_hDbhHelp = LoadLibrary(szTemp);
+          }
+        }
+      }
+    }
+    if (m_hDbhHelp == NULL)  // if not already loaded, try to load a default-one
+      m_hDbhHelp = LoadLibrary( _T("dbghelp.dll") );
+    if (m_hDbhHelp == NULL)
+      return FALSE;
+    pSI = (tSI) GetProcAddress(m_hDbhHelp, "SymInitialize" );
+    pSC = (tSC) GetProcAddress(m_hDbhHelp, "SymCleanup" );
+
+    pSW = (tSW) GetProcAddress(m_hDbhHelp, "StackWalk64" );
+    pSGO = (tSGO) GetProcAddress(m_hDbhHelp, "SymGetOptions" );
+    pSSO = (tSSO) GetProcAddress(m_hDbhHelp, "SymSetOptions" );
+
+    pSFTA = (tSFTA) GetProcAddress(m_hDbhHelp, "SymFunctionTableAccess64" );
+    pSGLFA = (tSGLFA) GetProcAddress(m_hDbhHelp, "SymGetLineFromAddr64" );
+    pSGMB = (tSGMB) GetProcAddress(m_hDbhHelp, "SymGetModuleBase64" );
+    pSGMI = (tSGMI) GetProcAddress(m_hDbhHelp, "SymGetModuleInfo64" );
+    //pSGMI_V3 = (tSGMI_V3) GetProcAddress(m_hDbhHelp, "SymGetModuleInfo64" );
+    pSGSFA = (tSGSFA) GetProcAddress(m_hDbhHelp, "SymGetSymFromAddr64" );
+    pUDSN = (tUDSN) GetProcAddress(m_hDbhHelp, "UnDecorateSymbolName" );
+    pSLM = (tSLM) GetProcAddress(m_hDbhHelp, "SymLoadModule64" );
+    pSGSP =(tSGSP) GetProcAddress(m_hDbhHelp, "SymGetSearchPath" );
+
+    if ( pSC == NULL || pSFTA == NULL || pSGMB == NULL || pSGMI == NULL ||
+      pSGO == NULL || pSGSFA == NULL || pSI == NULL || pSSO == NULL ||
+      pSW == NULL || pUDSN == NULL || pSLM == NULL )
+    {
+      FreeLibrary(m_hDbhHelp);
+      m_hDbhHelp = NULL;
+      pSC = NULL;
+      return FALSE;
+    }
+
+    // SymInitialize
+    if (szSymPath != NULL)
+      m_szSymPath = _strdup(szSymPath);
+    if (this->pSI(m_hProcess, m_szSymPath, FALSE) == FALSE)
+      this->m_parent->OnDbgHelpErr("SymInitialize", GetLastError(), 0);
+      
+    DWORD symOptions = this->pSGO();  // SymGetOptions
+    symOptions |= SYMOPT_LOAD_LINES;
+    symOptions |= SYMOPT_FAIL_CRITICAL_ERRORS;
+    //symOptions |= SYMOPT_NO_PROMPTS;
+    // SymSetOptions
+    symOptions = this->pSSO(symOptions);
+
+    char buf[StackWalker::STACKWALK_MAX_NAMELEN] = {0};
+    if (this->pSGSP != NULL)
+    {
+      if (this->pSGSP(m_hProcess, buf, StackWalker::STACKWALK_MAX_NAMELEN) == FALSE)
+        this->m_parent->OnDbgHelpErr("SymGetSearchPath", GetLastError(), 0);
+    }
+    char szUserName[1024] = {0};
+    DWORD dwSize = 1024;
+    GetUserNameA(szUserName, &dwSize);
+    this->m_parent->OnSymInit(buf, symOptions, szUserName);
+
+    return TRUE;
+  }
+
+  StackWalker *m_parent;
+
+  HMODULE m_hDbhHelp;
+  HANDLE m_hProcess;
+  LPSTR m_szSymPath;
+
+/*typedef struct IMAGEHLP_MODULE64_V3 {
+    DWORD    SizeOfStruct;           // set to sizeof(IMAGEHLP_MODULE64)
+    DWORD64  BaseOfImage;            // base load address of module
+    DWORD    ImageSize;              // virtual size of the loaded module
+    DWORD    TimeDateStamp;          // date/time stamp from pe header
+    DWORD    CheckSum;               // checksum from the pe header
+    DWORD    NumSyms;                // number of symbols in the symbol table
+    SYM_TYPE SymType;                // type of symbols loaded
+    CHAR     ModuleName[32];         // module name
+    CHAR     ImageName[256];         // image name
+    // new elements: 07-Jun-2002
+    CHAR     LoadedImageName[256];   // symbol file name
+    CHAR     LoadedPdbName[256];     // pdb file name
+    DWORD    CVSig;                  // Signature of the CV record in the debug directories
+    CHAR         CVData[MAX_PATH * 3];   // Contents of the CV record
+    DWORD    PdbSig;                 // Signature of PDB
+    GUID     PdbSig70;               // Signature of PDB (VC 7 and up)
+    DWORD    PdbAge;                 // DBI age of pdb
+    BOOL     PdbUnmatched;           // loaded an unmatched pdb
+    BOOL     DbgUnmatched;           // loaded an unmatched dbg
+    BOOL     LineNumbers;            // we have line number information
+    BOOL     GlobalSymbols;          // we have internal symbol information
+    BOOL     TypeInfo;               // we have type information
+    // new elements: 17-Dec-2003
+    BOOL     SourceIndexed;          // pdb supports source server
+    BOOL     Publics;                // contains public symbols
+};
+*/
+typedef struct IMAGEHLP_MODULE64_V2 {
+    DWORD    SizeOfStruct;           // set to sizeof(IMAGEHLP_MODULE64)
+    DWORD64  BaseOfImage;            // base load address of module
+    DWORD    ImageSize;              // virtual size of the loaded module
+    DWORD    TimeDateStamp;          // date/time stamp from pe header
+    DWORD    CheckSum;               // checksum from the pe header
+    DWORD    NumSyms;                // number of symbols in the symbol table
+    SYM_TYPE SymType;                // type of symbols loaded
+    CHAR     ModuleName[32];         // module name
+    CHAR     ImageName[256];         // image name
+    CHAR     LoadedImageName[256];   // symbol file name
+};
+
+
+  // SymCleanup()
+  typedef BOOL (__stdcall *tSC)( IN HANDLE hProcess );
+  tSC pSC;
+
+  // SymFunctionTableAccess64()
+  typedef PVOID (__stdcall *tSFTA)( HANDLE hProcess, DWORD64 AddrBase );
+  tSFTA pSFTA;
+
+  // SymGetLineFromAddr64()
+  typedef BOOL (__stdcall *tSGLFA)( IN HANDLE hProcess, IN DWORD64 dwAddr,
+    OUT PDWORD pdwDisplacement, OUT PIMAGEHLP_LINE64 Line );
+  tSGLFA pSGLFA;
+
+  // SymGetModuleBase64()
+  typedef DWORD64 (__stdcall *tSGMB)( IN HANDLE hProcess, IN DWORD64 dwAddr );
+  tSGMB pSGMB;
+
+  // SymGetModuleInfo64()
+  typedef BOOL (__stdcall *tSGMI)( IN HANDLE hProcess, IN DWORD64 dwAddr, OUT IMAGEHLP_MODULE64_V2 *ModuleInfo );
+  tSGMI pSGMI;
+
+//  // SymGetModuleInfo64()
+//  typedef BOOL (__stdcall *tSGMI_V3)( IN HANDLE hProcess, IN DWORD64 dwAddr, OUT IMAGEHLP_MODULE64_V3 *ModuleInfo );
+//  tSGMI_V3 pSGMI_V3;
+
+  // SymGetOptions()
+  typedef DWORD (__stdcall *tSGO)( VOID );
+  tSGO pSGO;
+
+  // SymGetSymFromAddr64()
+  typedef BOOL (__stdcall *tSGSFA)( IN HANDLE hProcess, IN DWORD64 dwAddr,
+    OUT PDWORD64 pdwDisplacement, OUT PIMAGEHLP_SYMBOL64 Symbol );
+  tSGSFA pSGSFA;
+
+  // SymInitialize()
+  typedef BOOL (__stdcall *tSI)( IN HANDLE hProcess, IN PSTR UserSearchPath, IN BOOL fInvadeProcess );
+  tSI pSI;
+
+  // SymLoadModule64()
+  typedef DWORD64 (__stdcall *tSLM)( IN HANDLE hProcess, IN HANDLE hFile,
+    IN PSTR ImageName, IN PSTR ModuleName, IN DWORD64 BaseOfDll, IN DWORD SizeOfDll );
+  tSLM pSLM;
+
+  // SymSetOptions()
+  typedef DWORD (__stdcall *tSSO)( IN DWORD SymOptions );
+  tSSO pSSO;
+
+  // StackWalk64()
+  typedef BOOL (__stdcall *tSW)( 
+    DWORD MachineType, 
+    HANDLE hProcess,
+    HANDLE hThread, 
+    LPSTACKFRAME64 StackFrame, 
+    PVOID ContextRecord,
+    PREAD_PROCESS_MEMORY_ROUTINE64 ReadMemoryRoutine,
+    PFUNCTION_TABLE_ACCESS_ROUTINE64 FunctionTableAccessRoutine,
+    PGET_MODULE_BASE_ROUTINE64 GetModuleBaseRoutine,
+    PTRANSLATE_ADDRESS_ROUTINE64 TranslateAddress );
+  tSW pSW;
+
+  // UnDecorateSymbolName()
+  typedef DWORD (__stdcall WINAPI *tUDSN)( PCSTR DecoratedName, PSTR UnDecoratedName,
+    DWORD UndecoratedLength, DWORD Flags );
+  tUDSN pUDSN;
+
+  typedef BOOL (__stdcall WINAPI *tSGSP)(HANDLE hProcess, PSTR SearchPath, DWORD SearchPathLength);
+  tSGSP pSGSP;
+
+
+private:
+  // **************************************** ToolHelp32 ************************
+  #define MAX_MODULE_NAME32 255
+  #define TH32CS_SNAPMODULE   0x00000008
+  #pragma pack( push, 8 )
+  typedef struct tagMODULEENTRY32
+  {
+      DWORD   dwSize;
+      DWORD   th32ModuleID;       // This module
+      DWORD   th32ProcessID;      // owning process
+      DWORD   GlblcntUsage;       // Global usage count on the module
+      DWORD   ProccntUsage;       // Module usage count in th32ProcessID's context
+      BYTE  * modBaseAddr;        // Base address of module in th32ProcessID's context
+      DWORD   modBaseSize;        // Size in bytes of module starting at modBaseAddr
+      HMODULE hModule;            // The hModule of this module in th32ProcessID's context
+      char    szModule[MAX_MODULE_NAME32 + 1];
+      char    szExePath[MAX_PATH];
+  } MODULEENTRY32;
+  typedef MODULEENTRY32 *  PMODULEENTRY32;
+  typedef MODULEENTRY32 *  LPMODULEENTRY32;
+  #pragma pack( pop )
+
+  BOOL GetModuleListTH32(HANDLE hProcess, DWORD pid)
+  {
+    // CreateToolhelp32Snapshot()
+    typedef HANDLE (__stdcall *tCT32S)(DWORD dwFlags, DWORD th32ProcessID);
+    // Module32First()
+    typedef BOOL (__stdcall *tM32F)(HANDLE hSnapshot, LPMODULEENTRY32 lpme);
+    // Module32Next()
+    typedef BOOL (__stdcall *tM32N)(HANDLE hSnapshot, LPMODULEENTRY32 lpme);
+
+    // try both dlls...
+    const TCHAR *dllname[] = { _T("kernel32.dll"), _T("tlhelp32.dll") };
+    HINSTANCE hToolhelp = NULL;
+    tCT32S pCT32S = NULL;
+    tM32F pM32F = NULL;
+    tM32N pM32N = NULL;
+
+    HANDLE hSnap;
+    MODULEENTRY32 me;
+    me.dwSize = sizeof(me);
+    BOOL keepGoing;
+    size_t i;
+
+    for (i = 0; i<(sizeof(dllname) / sizeof(dllname[0])); i++ )
+    {
+      hToolhelp = LoadLibrary( dllname[i] );
+      if (hToolhelp == NULL)
+        continue;
+      pCT32S = (tCT32S) GetProcAddress(hToolhelp, "CreateToolhelp32Snapshot");
+      pM32F = (tM32F) GetProcAddress(hToolhelp, "Module32First");
+      pM32N = (tM32N) GetProcAddress(hToolhelp, "Module32Next");
+      if ( (pCT32S != NULL) && (pM32F != NULL) && (pM32N != NULL) )
+        break; // found the functions!
+      FreeLibrary(hToolhelp);
+      hToolhelp = NULL;
+    }
+
+    if (hToolhelp == NULL)
+      return FALSE;
+
+    hSnap = pCT32S( TH32CS_SNAPMODULE, pid );
+    if (hSnap == (HANDLE) -1)
+      return FALSE;
+
+    keepGoing = !!pM32F( hSnap, &me );
+    int cnt = 0;
+    while (keepGoing)
+    {
+      this->LoadModule(hProcess, me.szExePath, me.szModule, (DWORD64) me.modBaseAddr, me.modBaseSize);
+      cnt++;
+      keepGoing = !!pM32N( hSnap, &me );
+    }
+    CloseHandle(hSnap);
+    FreeLibrary(hToolhelp);
+    if (cnt <= 0)
+      return FALSE;
+    return TRUE;
+  }  // GetModuleListTH32
+
+  // **************************************** PSAPI ************************
+  typedef struct _MODULEINFO {
+      LPVOID lpBaseOfDll;
+      DWORD SizeOfImage;
+      LPVOID EntryPoint;
+  } MODULEINFO, *LPMODULEINFO;
+
+  BOOL GetModuleListPSAPI(HANDLE hProcess)
+  {
+    // EnumProcessModules()
+    typedef BOOL (__stdcall *tEPM)(HANDLE hProcess, HMODULE *lphModule, DWORD cb, LPDWORD lpcbNeeded );
+    // GetModuleFileNameEx()
+    typedef DWORD (__stdcall *tGMFNE)(HANDLE hProcess, HMODULE hModule, LPSTR lpFilename, DWORD nSize );
+    // GetModuleBaseName()
+    typedef DWORD (__stdcall *tGMBN)(HANDLE hProcess, HMODULE hModule, LPSTR lpFilename, DWORD nSize );
+    // GetModuleInformation()
+    typedef BOOL (__stdcall *tGMI)(HANDLE hProcess, HMODULE hModule, LPMODULEINFO pmi, DWORD nSize );
+
+    HINSTANCE hPsapi;
+    tEPM pEPM;
+    tGMFNE pGMFNE;
+    tGMBN pGMBN;
+    tGMI pGMI;
+
+    DWORD i;
+    //ModuleEntry e;
+    DWORD cbNeeded;
+    MODULEINFO mi;
+    HMODULE *hMods = 0;
+    char *tt = NULL;
+    char *tt2 = NULL;
+    const SIZE_T TTBUFLEN = 8096;
+    int cnt = 0;
+
+    hPsapi = LoadLibrary( _T("psapi.dll") );
+    if (hPsapi == NULL)
+      return FALSE;
+
+    pEPM = (tEPM) GetProcAddress( hPsapi, "EnumProcessModules" );
+    pGMFNE = (tGMFNE) GetProcAddress( hPsapi, "GetModuleFileNameExA" );
+    pGMBN = (tGMFNE) GetProcAddress( hPsapi, "GetModuleBaseNameA" );
+    pGMI = (tGMI) GetProcAddress( hPsapi, "GetModuleInformation" );
+    if ( (pEPM == NULL) || (pGMFNE == NULL) || (pGMBN == NULL) || (pGMI == NULL) )
+    {
+      // we couldn´t find all functions
+      FreeLibrary(hPsapi);
+      return FALSE;
+    }
+
+    hMods = (HMODULE*) malloc(sizeof(HMODULE) * (TTBUFLEN / sizeof HMODULE));
+    tt = (char*) malloc(sizeof(char) * TTBUFLEN);
+    tt2 = (char*) malloc(sizeof(char) * TTBUFLEN);
+    if ( (hMods == NULL) || (tt == NULL) || (tt2 == NULL) )
+      goto cleanup;
+
+    if ( ! pEPM( hProcess, hMods, TTBUFLEN, &cbNeeded ) )
+    {
+      //_ftprintf(fLogFile, _T("%lu: EPM failed, GetLastError = %lu\n"), g_dwShowCount, gle );
+      goto cleanup;
+    }
+
+    if ( cbNeeded > TTBUFLEN )
+    {
+      //_ftprintf(fLogFile, _T("%lu: More than %lu module handles. Huh?\n"), g_dwShowCount, lenof( hMods ) );
+      goto cleanup;
+    }
+
+    for ( i = 0; i < cbNeeded / sizeof hMods[0]; i++ )
+    {
+      // base address, size
+      pGMI(hProcess, hMods[i], &mi, sizeof mi );
+      // image file name
+      tt[0] = 0;
+      pGMFNE(hProcess, hMods[i], tt, TTBUFLEN );
+      // module name
+      tt2[0] = 0;
+      pGMBN(hProcess, hMods[i], tt2, TTBUFLEN );
+
+      DWORD dwRes = this->LoadModule(hProcess, tt, tt2, (DWORD64) mi.lpBaseOfDll, mi.SizeOfImage);
+      if (dwRes != ERROR_SUCCESS)
+        this->m_parent->OnDbgHelpErr("LoadModule", dwRes, 0);
+      cnt++;
+    }
+
+  cleanup:
+    if (hPsapi != NULL) FreeLibrary(hPsapi);
+    if (tt2 != NULL) free(tt2);
+    if (tt != NULL) free(tt);
+    if (hMods != NULL) free(hMods);
+
+    return cnt != 0;
+  }  // GetModuleListPSAPI
+
+  DWORD LoadModule(HANDLE hProcess, LPCSTR img, LPCSTR mod, DWORD64 baseAddr, DWORD size)
+  {
+    CHAR *szImg = _strdup(img);
+    CHAR *szMod = _strdup(mod);
+    DWORD result = ERROR_SUCCESS;
+    if ( (szImg == NULL) || (szMod == NULL) )
+      result = ERROR_NOT_ENOUGH_MEMORY;
+    else
+    {
+      if (pSLM(hProcess, 0, szImg, szMod, baseAddr, size) == 0)
+        result = GetLastError();
+    }
+    ULONGLONG fileVersion = 0;
+    if ( (m_parent != NULL) && (szImg != NULL) )
+    {
+      // try to retrive the file-version:
+      if ( (this->m_parent->m_options & StackWalker::RetrieveFileVersion) != 0)
+      {
+        VS_FIXEDFILEINFO *fInfo = NULL;
+        DWORD dwHandle;
+        DWORD dwSize = GetFileVersionInfoSizeA(szImg, &dwHandle);
+        if (dwSize > 0)
+        {
+          LPVOID vData = malloc(dwSize);
+          if (vData != NULL)
+          {
+            if (GetFileVersionInfoA(szImg, dwHandle, dwSize, vData) != 0)
+            {
+              UINT len;
+              TCHAR szSubBlock[] = _T("\\");
+              if (VerQueryValue(vData, szSubBlock, (LPVOID*) &fInfo, &len) == 0)
+                fInfo = NULL;
+              else
+              {
+                fileVersion = ((ULONGLONG)fInfo->dwFileVersionLS) + ((ULONGLONG)fInfo->dwFileVersionMS << 32);
+              }
+            }
+            free(vData);
+          }
+        }
+      }
+
+      // Retrive some additional-infos about the module
+      IMAGEHLP_MODULE64_V2 Module;
+      const char *szSymType = "-unknown-";
+      if (this->GetModuleInfo(hProcess, baseAddr, &Module) != FALSE)
+      {
+        switch(Module.SymType)
+        {
+          case SymNone:
+            szSymType = "-nosymbols-";
+            break;
+          case SymCoff:
+            szSymType = "COFF";
+            break;
+          case SymCv:
+            szSymType = "CV";
+            break;
+          case SymPdb:
+            szSymType = "PDB";
+            break;
+          case SymExport:
+            szSymType = "-exported-";
+            break;
+          case SymDeferred:
+            szSymType = "-deferred-";
+            break;
+          case SymSym:
+            szSymType = "SYM";
+            break;
+          case 8: //SymVirtual:
+            szSymType = "Virtual";
+            break;
+          case 9: // SymDia:
+            szSymType = "DIA";
+            break;
+        }
+      }
+      this->m_parent->OnLoadModule(img, mod, baseAddr, size, result, szSymType, Module.LoadedImageName, fileVersion);
+    }
+    if (szImg != NULL) free(szImg);
+    if (szMod != NULL) free(szMod);
+    return result;
+  }
+public:
+  BOOL LoadModules(HANDLE hProcess, DWORD dwProcessId)
+  {
+    // first try toolhelp32
+    if (GetModuleListTH32(hProcess, dwProcessId))
+      return true;
+    // then try psapi
+    return GetModuleListPSAPI(hProcess);
+  }
+
+
+  BOOL GetModuleInfo(HANDLE hProcess, DWORD64 baseAddr, IMAGEHLP_MODULE64_V2 *pModuleInfo)
+  {
+    if(this->pSGMI == NULL)
+    {
+      SetLastError(ERROR_DLL_INIT_FAILED);
+      return FALSE;
+    }
+    // First try to use the larger ModuleInfo-Structure
+//    memset(pModuleInfo, 0, sizeof(IMAGEHLP_MODULE64_V3));
+//    pModuleInfo->SizeOfStruct = sizeof(IMAGEHLP_MODULE64_V3);
+//    if (this->pSGMI_V3 != NULL)
+//    {
+//      if (this->pSGMI_V3(hProcess, baseAddr, pModuleInfo) != FALSE)
+//        return TRUE;
+//      // check if the parameter was wrong (size is bad...)
+//      if (GetLastError() != ERROR_INVALID_PARAMETER)
+//        return FALSE;
+//    }
+    // could not retrive the bigger structure, try with the smaller one (as defined in VC7.1)...
+    pModuleInfo->SizeOfStruct = sizeof(IMAGEHLP_MODULE64_V2);
+    void *pData = malloc(4096); // reserve enough memory, so the bug in v6.3.5.1 does not lead to memory-overwrites...
+    if (pData == NULL)
+    {
+      SetLastError(ERROR_NOT_ENOUGH_MEMORY);
+      return FALSE;
+    }
+    memcpy(pData, pModuleInfo, sizeof(IMAGEHLP_MODULE64_V2));
+    if (this->pSGMI(hProcess, baseAddr, (IMAGEHLP_MODULE64_V2*) pData) != FALSE)
+    {
+      // only copy as much memory as is reserved...
+      memcpy(pModuleInfo, pData, sizeof(IMAGEHLP_MODULE64_V2));
+      pModuleInfo->SizeOfStruct = sizeof(IMAGEHLP_MODULE64_V2);
+      free(pData);
+      return TRUE;
+    }
+    free(pData);
+    SetLastError(ERROR_DLL_INIT_FAILED);
+    return FALSE;
+  }
+};
+
+// #############################################################
+StackWalker::StackWalker(DWORD dwProcessId, HANDLE hProcess)
+{
+  this->m_options = OptionsAll;
+  this->m_modulesLoaded = FALSE;
+  this->m_hProcess = hProcess;
+  this->m_sw = new StackWalkerInternal(this, this->m_hProcess);
+  this->m_dwProcessId = dwProcessId;
+  this->m_szSymPath = NULL;
+}
+StackWalker::StackWalker(int options, LPCSTR szSymPath, DWORD dwProcessId, HANDLE hProcess)
+{
+  this->m_options = options;
+  this->m_modulesLoaded = FALSE;
+  this->m_hProcess = hProcess;
+  this->m_sw = new StackWalkerInternal(this, this->m_hProcess);
+  this->m_dwProcessId = dwProcessId;
+  if (szSymPath != NULL)
+  {
+    this->m_szSymPath = _strdup(szSymPath);
+    this->m_options |= SymBuildPath;
+  }
+  else
+    this->m_szSymPath = NULL;
+}
+
+StackWalker::~StackWalker()
+{
+  if (m_szSymPath != NULL)
+    free(m_szSymPath);
+  m_szSymPath = NULL;
+  if (this->m_sw != NULL)
+    delete this->m_sw;
+  this->m_sw = NULL;
+}
+
+BOOL StackWalker::LoadModules()
+{
+  if (this->m_sw == NULL)
+  {
+    SetLastError(ERROR_DLL_INIT_FAILED);
+    return FALSE;
+  }
+  if (m_modulesLoaded != FALSE)
+    return TRUE;
+
+  // Build the sym-path:
+  char *szSymPath = NULL;
+  if ( (this->m_options & SymBuildPath) != 0)
+  {
+    const size_t nSymPathLen = 4096;
+    szSymPath = (char*) malloc(nSymPathLen);
+    if (szSymPath == NULL)
+    {
+      SetLastError(ERROR_NOT_ENOUGH_MEMORY);
+      return FALSE;
+    }
+    szSymPath[0] = 0;
+    // Now first add the (optional) provided sympath:
+    if (this->m_szSymPath != NULL)
+    {
+      strcat_s(szSymPath, nSymPathLen, this->m_szSymPath);
+      strcat_s(szSymPath, nSymPathLen, ";");
+    }
+
+    strcat_s(szSymPath, nSymPathLen, ".;");
+
+    const size_t nTempLen = 1024;
+    char szTemp[nTempLen];
+    // Now add the current directory:
+    if (GetCurrentDirectoryA(nTempLen, szTemp) > 0)
+    {
+      szTemp[nTempLen-1] = 0;
+      strcat_s(szSymPath, nSymPathLen, szTemp);
+      strcat_s(szSymPath, nSymPathLen, ";");
+    }
+
+    // Now add the path for the main-module:
+    if (GetModuleFileNameA(NULL, szTemp, nTempLen) > 0)
+    {
+      szTemp[nTempLen-1] = 0;
+      for (char *p = (szTemp+strlen(szTemp)-1); p >= szTemp; --p)
+      {
+        // locate the rightmost path separator
+        if ( (*p == '\\') || (*p == '/') || (*p == ':') )
+        {
+          *p = 0;
+          break;
+        }
+      }  // for (search for path separator...)
+      if (strlen(szTemp) > 0)
+      {
+        strcat_s(szSymPath, nSymPathLen, szTemp);
+        strcat_s(szSymPath, nSymPathLen, ";");
+      }
+    }
+    if (GetEnvironmentVariableA("_NT_SYMBOL_PATH", szTemp, nTempLen) > 0)
+    {
+      szTemp[nTempLen-1] = 0;
+      strcat_s(szSymPath, nSymPathLen, szTemp);
+      strcat_s(szSymPath, nSymPathLen, ";");
+    }
+    if (GetEnvironmentVariableA("_NT_ALTERNATE_SYMBOL_PATH", szTemp, nTempLen) > 0)
+    {
+      szTemp[nTempLen-1] = 0;
+      strcat_s(szSymPath, nSymPathLen, szTemp);
+      strcat_s(szSymPath, nSymPathLen, ";");
+    }
+    if (GetEnvironmentVariableA("SYSTEMROOT", szTemp, nTempLen) > 0)
+    {
+      szTemp[nTempLen-1] = 0;
+      strcat_s(szSymPath, nSymPathLen, szTemp);
+      strcat_s(szSymPath, nSymPathLen, ";");
+      // also add the "system32"-directory:
+      strcat_s(szTemp, nTempLen, "\\system32");
+      strcat_s(szSymPath, nSymPathLen, szTemp);
+      strcat_s(szSymPath, nSymPathLen, ";");
+    }
+
+    if ( (this->m_options & SymBuildPath) != 0)
+    {
+      if (GetEnvironmentVariableA("SYSTEMDRIVE", szTemp, nTempLen) > 0)
+      {
+        szTemp[nTempLen-1] = 0;
+        strcat_s(szSymPath, nSymPathLen, "SRV*");
+        strcat_s(szSymPath, nSymPathLen, szTemp);
+        strcat_s(szSymPath, nSymPathLen, "\\websymbols");
+        strcat_s(szSymPath, nSymPathLen, "*http://msdl.microsoft.com/download/symbols;");
+      }
+      else
+        strcat_s(szSymPath, nSymPathLen, "SRV*c:\\websymbols*http://msdl.microsoft.com/download/symbols;");
+    }
+  }
+
+  // First Init the whole stuff...
+  BOOL bRet = this->m_sw->Init(szSymPath);
+  if (szSymPath != NULL) free(szSymPath); szSymPath = NULL;
+  if (bRet == FALSE)
+  {
+    this->OnDbgHelpErr("Error while initializing dbghelp.dll", 0, 0);
+    SetLastError(ERROR_DLL_INIT_FAILED);
+    return FALSE;
+  }
+
+  bRet = this->m_sw->LoadModules(this->m_hProcess, this->m_dwProcessId);
+  if (bRet != FALSE)
+    m_modulesLoaded = TRUE;
+  return bRet;
+}
+
+
+// The following is used to pass the "userData"-Pointer to the user-provided readMemoryFunction
+// This has to be done due to a problem with the "hProcess"-parameter in x64...
+// Because this class is in no case multi-threading-enabled (because of the limitations 
+// of dbghelp.dll) it is "safe" to use a static-variable
+static StackWalker::PReadProcessMemoryRoutine s_readMemoryFunction = NULL;
+static LPVOID s_readMemoryFunction_UserData = NULL;
+
+BOOL StackWalker::ShowCallstack(HANDLE hThread, const CONTEXT *context, PReadProcessMemoryRoutine readMemoryFunction, LPVOID pUserData)
+{
+  CONTEXT c;;
+  CallstackEntry csEntry;
+  IMAGEHLP_SYMBOL64 *pSym = NULL;
+  StackWalkerInternal::IMAGEHLP_MODULE64_V2 Module;
+  IMAGEHLP_LINE64 Line;
+  int frameNum;
+
+  if (m_modulesLoaded == FALSE)
+    this->LoadModules();  // ignore the result...
+
+  if (this->m_sw->m_hDbhHelp == NULL)
+  {
+    SetLastError(ERROR_DLL_INIT_FAILED);
+    return FALSE;
+  }
+
+  s_readMemoryFunction = readMemoryFunction;
+  s_readMemoryFunction_UserData = pUserData;
+
+  if (context == NULL)
+  {
+    // If no context is provided, capture the context
+    if (hThread == GetCurrentThread())
+    {
+      GET_CURRENT_CONTEXT(c, USED_CONTEXT_FLAGS);
+    }
+    else
+    {
+      SuspendThread(hThread);
+      memset(&c, 0, sizeof(CONTEXT));
+      c.ContextFlags = USED_CONTEXT_FLAGS;
+      if (GetThreadContext(hThread, &c) == FALSE)
+      {
+        ResumeThread(hThread);
+        return FALSE;
+      }
+    }
+  }
+  else
+    c = *context;
+
+  // init STACKFRAME for first call
+  STACKFRAME64 s; // in/out stackframe
+  memset(&s, 0, sizeof(s));
+  DWORD imageType;
+#ifdef _M_IX86
+  // normally, call ImageNtHeader() and use machine info from PE header
+  imageType = IMAGE_FILE_MACHINE_I386;
+  s.AddrPC.Offset = c.Eip;
+  s.AddrPC.Mode = AddrModeFlat;
+  s.AddrFrame.Offset = c.Ebp;
+  s.AddrFrame.Mode = AddrModeFlat;
+  s.AddrStack.Offset = c.Esp;
+  s.AddrStack.Mode = AddrModeFlat;
+#elif _M_X64
+  imageType = IMAGE_FILE_MACHINE_AMD64;
+  s.AddrPC.Offset = c.Rip;
+  s.AddrPC.Mode = AddrModeFlat;
+  s.AddrFrame.Offset = c.Rsp;
+  s.AddrFrame.Mode = AddrModeFlat;
+  s.AddrStack.Offset = c.Rsp;
+  s.AddrStack.Mode = AddrModeFlat;
+#elif _M_IA64
+  imageType = IMAGE_FILE_MACHINE_IA64;
+  s.AddrPC.Offset = c.StIIP;
+  s.AddrPC.Mode = AddrModeFlat;
+  s.AddrFrame.Offset = c.IntSp;
+  s.AddrFrame.Mode = AddrModeFlat;
+  s.AddrBStore.Offset = c.RsBSP;
+  s.AddrBStore.Mode = AddrModeFlat;
+  s.AddrStack.Offset = c.IntSp;
+  s.AddrStack.Mode = AddrModeFlat;
+#else
+#error "Platform not supported!"
+#endif
+
+  pSym = (IMAGEHLP_SYMBOL64 *) malloc(sizeof(IMAGEHLP_SYMBOL64) + STACKWALK_MAX_NAMELEN);
+  if (!pSym) goto cleanup;  // not enough memory...
+  memset(pSym, 0, sizeof(IMAGEHLP_SYMBOL64) + STACKWALK_MAX_NAMELEN);
+  pSym->SizeOfStruct = sizeof(IMAGEHLP_SYMBOL64);
+  pSym->MaxNameLength = STACKWALK_MAX_NAMELEN;
+
+  memset(&Line, 0, sizeof(Line));
+  Line.SizeOfStruct = sizeof(Line);
+
+  memset(&Module, 0, sizeof(Module));
+  Module.SizeOfStruct = sizeof(Module);
+
+  for (frameNum = 0; ; ++frameNum )
+  {
+    // get next stack frame (StackWalk64(), SymFunctionTableAccess64(), SymGetModuleBase64())
+    // if this returns ERROR_INVALID_ADDRESS (487) or ERROR_NOACCESS (998), you can
+    // assume that either you are done, or that the stack is so hosed that the next
+    // deeper frame could not be found.
+    // CONTEXT need not to be suplied if imageTyp is IMAGE_FILE_MACHINE_I386!
+    if ( ! this->m_sw->pSW(imageType, this->m_hProcess, hThread, &s, &c, myReadProcMem, this->m_sw->pSFTA, this->m_sw->pSGMB, NULL) )
+    {
+      this->OnDbgHelpErr("StackWalk64", GetLastError(), s.AddrPC.Offset);
+      break;
+    }
+
+    csEntry.offset = s.AddrPC.Offset;
+    csEntry.name[0] = 0;
+    csEntry.undName[0] = 0;
+    csEntry.undFullName[0] = 0;
+    csEntry.offsetFromSmybol = 0;
+    csEntry.offsetFromLine = 0;
+    csEntry.lineFileName[0] = 0;
+    csEntry.lineNumber = 0;
+    csEntry.loadedImageName[0] = 0;
+    csEntry.moduleName[0] = 0;
+    if (s.AddrPC.Offset == s.AddrReturn.Offset)
+    {
+      this->OnDbgHelpErr("StackWalk64-Endless-Callstack!", 0, s.AddrPC.Offset);
+      break;
+    }
+    if (s.AddrPC.Offset != 0)
+    {
+      // we seem to have a valid PC
+      // show procedure info (SymGetSymFromAddr64())
+      if (this->m_sw->pSGSFA(this->m_hProcess, s.AddrPC.Offset, &(csEntry.offsetFromSmybol), pSym) != FALSE)
+      {
+        // TODO: Mache dies sicher...!
+        strcpy_s(csEntry.name, pSym->Name);
+        // UnDecorateSymbolName()
+        this->m_sw->pUDSN( pSym->Name, csEntry.undName, STACKWALK_MAX_NAMELEN, UNDNAME_NAME_ONLY );
+        this->m_sw->pUDSN( pSym->Name, csEntry.undFullName, STACKWALK_MAX_NAMELEN, UNDNAME_COMPLETE );
+      }
+      else
+      {
+        this->OnDbgHelpErr("SymGetSymFromAddr64", GetLastError(), s.AddrPC.Offset);
+      }
+
+      // show line number info, NT5.0-method (SymGetLineFromAddr64())
+      if (this->m_sw->pSGLFA != NULL )
+      { // yes, we have SymGetLineFromAddr64()
+        if (this->m_sw->pSGLFA(this->m_hProcess, s.AddrPC.Offset, &(csEntry.offsetFromLine), &Line) != FALSE)
+        {
+          csEntry.lineNumber = Line.LineNumber;
+          // TODO: Mache dies sicher...!
+          strcpy_s(csEntry.lineFileName, Line.FileName);
+        }
+        else
+        {
+          this->OnDbgHelpErr("SymGetLineFromAddr64", GetLastError(), s.AddrPC.Offset);
+        }
+      } // yes, we have SymGetLineFromAddr64()
+
+      // show module info (SymGetModuleInfo64())
+      if (this->m_sw->GetModuleInfo(this->m_hProcess, s.AddrPC.Offset, &Module ) != FALSE)
+      { // got module info OK
+        switch ( Module.SymType )
+        {
+        case SymNone:
+          csEntry.symTypeString = "-nosymbols-";
+          break;
+        case SymCoff:
+          csEntry.symTypeString = "COFF";
+          break;
+        case SymCv:
+          csEntry.symTypeString = "CV";
+          break;
+        case SymPdb:
+          csEntry.symTypeString = "PDB";
+          break;
+        case SymExport:
+          csEntry.symTypeString = "-exported-";
+          break;
+        case SymDeferred:
+          csEntry.symTypeString = "-deferred-";
+          break;
+        case SymSym:
+          csEntry.symTypeString = "SYM";
+          break;
+#if API_VERSION_NUMBER >= 9
+        case SymDia:
+          csEntry.symTypeString = "DIA";
+          break;
+#endif
+        case 8: //SymVirtual:
+          csEntry.symTypeString = "Virtual";
+          break;
+        default:
+          //_snprintf( ty, sizeof ty, "symtype=%ld", (long) Module.SymType );
+          csEntry.symTypeString = NULL;
+          break;
+        }
+
+        // TODO: Mache dies sicher...!
+        strcpy_s(csEntry.moduleName, Module.ModuleName);
+        csEntry.baseOfImage = Module.BaseOfImage;
+        strcpy_s(csEntry.loadedImageName, Module.LoadedImageName);
+      } // got module info OK
+      else
+      {
+        this->OnDbgHelpErr("SymGetModuleInfo64", GetLastError(), s.AddrPC.Offset);
+      }
+    } // we seem to have a valid PC
+
+    CallstackEntryType et = nextEntry;
+    if (frameNum == 0)
+      et = firstEntry;
+    this->OnCallstackEntry(et, csEntry);
+    
+    if (s.AddrReturn.Offset == 0)
+    {
+      this->OnCallstackEntry(lastEntry, csEntry);
+      SetLastError(ERROR_SUCCESS);
+      break;
+    }
+  } // for ( frameNum )
+
+  cleanup:
+    if (pSym) free( pSym );
+
+  if (context == NULL)
+    ResumeThread(hThread);
+
+  return TRUE;
+}
+
+BOOL __stdcall StackWalker::myReadProcMem(
+    HANDLE      hProcess,
+    DWORD64     qwBaseAddress,
+    PVOID       lpBuffer,
+    DWORD       nSize,
+    LPDWORD     lpNumberOfBytesRead
+    )
+{
+  if (s_readMemoryFunction == NULL)
+  {
+    SIZE_T st;
+    BOOL bRet = ReadProcessMemory(hProcess, (LPVOID) qwBaseAddress, lpBuffer, nSize, &st);
+    *lpNumberOfBytesRead = (DWORD) st;
+    //printf("ReadMemory: hProcess: %p, baseAddr: %p, buffer: %p, size: %d, read: %d, result: %d\n", hProcess, (LPVOID) qwBaseAddress, lpBuffer, nSize, (DWORD) st, (DWORD) bRet);
+    return bRet;
+  }
+  else
+  {
+    return s_readMemoryFunction(hProcess, qwBaseAddress, lpBuffer, nSize, lpNumberOfBytesRead, s_readMemoryFunction_UserData);
+  }
+}
+
+void StackWalker::OnLoadModule(LPCSTR img, LPCSTR mod, DWORD64 baseAddr, DWORD size, DWORD result, LPCSTR symType, LPCSTR pdbName, ULONGLONG fileVersion)
+{
+  CHAR buffer[STACKWALK_MAX_NAMELEN];
+  if (fileVersion == 0)
+    _snprintf_s(buffer, STACKWALK_MAX_NAMELEN, "%s:%s (%p), size: %d (result: %d), SymType: '%s', PDB: '%s'\n", img, mod, (LPVOID) baseAddr, size, result, symType, pdbName);
+  else
+  {
+    DWORD v4 = (DWORD) fileVersion & 0xFFFF;
+    DWORD v3 = (DWORD) (fileVersion>>16) & 0xFFFF;
+    DWORD v2 = (DWORD) (fileVersion>>32) & 0xFFFF;
+    DWORD v1 = (DWORD) (fileVersion>>48) & 0xFFFF;
+    _snprintf_s(buffer, STACKWALK_MAX_NAMELEN, "%s:%s (%p), size: %d (result: %d), SymType: '%s', PDB: '%s', fileVersion: %d.%d.%d.%d\n", img, mod, (LPVOID) baseAddr, size, result, symType, pdbName, v1, v2, v3, v4);
+  }
+  OnOutput(buffer);
+}
+
+void StackWalker::OnCallstackEntry(CallstackEntryType eType, CallstackEntry &entry)
+{
+  CHAR buffer[STACKWALK_MAX_NAMELEN];
+  if ( (eType != lastEntry) && (entry.offset != 0) )
+  {
+    if (entry.name[0] == 0)
+      strcpy_s(entry.name, "(function-name not available)");
+    if (entry.undName[0] != 0)
+      strcpy_s(entry.name, entry.undName);
+    if (entry.undFullName[0] != 0)
+      strcpy_s(entry.name, entry.undFullName);
+    if (entry.lineFileName[0] == 0)
+    {
+      strcpy_s(entry.lineFileName, "(filename not available)");
+      if (entry.moduleName[0] == 0)
+        strcpy_s(entry.moduleName, "(module-name not available)");
+      _snprintf_s(buffer, STACKWALK_MAX_NAMELEN, "%p (%s): %s: %s\n", (LPVOID) entry.offset, entry.moduleName, entry.lineFileName, entry.name);
+    }
+    else
+      _snprintf_s(buffer, STACKWALK_MAX_NAMELEN, "%s (%d): %s\n", entry.lineFileName, entry.lineNumber, entry.name);
+    OnOutput(buffer);
+  }
+}
+
+void StackWalker::OnDbgHelpErr(LPCSTR szFuncName, DWORD gle, DWORD64 addr)
+{
+  CHAR buffer[STACKWALK_MAX_NAMELEN];
+  _snprintf_s(buffer, STACKWALK_MAX_NAMELEN, "ERROR: %s, GetLastError: %d (Address: %p)\n", szFuncName, gle, (LPVOID) addr);
+  OnOutput(buffer);
+}
+
+void StackWalker::OnSymInit(LPCSTR szSearchPath, DWORD symOptions, LPCSTR szUserName)
+{
+  CHAR buffer[STACKWALK_MAX_NAMELEN];
+  _snprintf_s(buffer, STACKWALK_MAX_NAMELEN, "SymInit: Symbol-SearchPath: '%s', symOptions: %d, UserName: '%s'\n", szSearchPath, symOptions, szUserName);
+  OnOutput(buffer);
+  // Also display the OS-version
+#if _MSC_VER <= 1200
+  OSVERSIONINFOA ver;
+  ZeroMemory(&ver, sizeof(OSVERSIONINFOA));
+  ver.dwOSVersionInfoSize = sizeof(ver);
+  if (GetVersionExA(&ver) != FALSE)
+  {
+    _snprintf_s(buffer, STACKWALK_MAX_NAMELEN, "OS-Version: %d.%d.%d (%s)\n", 
+      ver.dwMajorVersion, ver.dwMinorVersion, ver.dwBuildNumber,
+      ver.szCSDVersion);
+    OnOutput(buffer);
+  }
+#else
+  OSVERSIONINFOEXA ver;
+  ZeroMemory(&ver, sizeof(OSVERSIONINFOEXA));
+  ver.dwOSVersionInfoSize = sizeof(ver);
+  if (GetVersionExA( (OSVERSIONINFOA*) &ver) != FALSE)
+  {
+    _snprintf_s(buffer, STACKWALK_MAX_NAMELEN, "OS-Version: %d.%d.%d (%s) 0x%x-0x%x\n", 
+      ver.dwMajorVersion, ver.dwMinorVersion, ver.dwBuildNumber,
+      ver.szCSDVersion, ver.wSuiteMask, ver.wProductType);
+    OnOutput(buffer);
+  }
+#endif
+}
+
+void StackWalker::OnOutput(LPCSTR buffer)
+{
+  OutputDebugStringA(buffer);
+}

--- a/Profiler/StackWalker.cpp
+++ b/Profiler/StackWalker.cpp
@@ -1,143 +1,196 @@
 /**********************************************************************
- * 
- * StackWalker.cpp
- *
- *
- * History:
- *  2005-07-27   v1    - First public release on http://www.codeproject.com/
- *                       http://www.codeproject.com/threads/StackWalker.asp
- *  2005-07-28   v2    - Changed the params of the constructor and ShowCallstack
- *                       (to simplify the usage)
- *  2005-08-01   v3    - Changed to use 'CONTEXT_FULL' instead of CONTEXT_ALL 
- *                       (should also be enough)
- *                     - Changed to compile correctly with the PSDK of VC7.0
- *                       (GetFileVersionInfoSizeA and GetFileVersionInfoA is wrongly defined:
- *                        it uses LPSTR instead of LPCSTR as first paremeter)
- *                     - Added declarations to support VC5/6 without using 'dbghelp.h'
- *                     - Added a 'pUserData' member to the ShowCallstack function and the 
- *                       PReadProcessMemoryRoutine declaration (to pass some user-defined data, 
- *                       which can be used in the readMemoryFunction-callback)
- *  2005-08-02   v4    - OnSymInit now also outputs the OS-Version by default
- *                     - Added example for doing an exception-callstack-walking in main.cpp
- *                       (thanks to owillebo: http://www.codeproject.com/script/profile/whos_who.asp?id=536268)
- *  2005-08-05   v5    - Removed most Lint (http://www.gimpel.com/) errors... thanks to Okko Willeboordse!
- *
- **********************************************************************/
-#include <windows.h>
-#include <tchar.h>
-#include <stdio.h>
-#pragma comment(lib, "version.lib")  // for "VerQueryValue"
+*
+* StackWalker.cpp
+* https://github.com/JochenKalmbach/StackWalker
+*
+* Old location: http://stackwalker.codeplex.com/
+*
+*
+* History:
+*  2005-07-27   v1    - First public release on http://www.codeproject.com/
+*                       http://www.codeproject.com/threads/StackWalker.asp
+*  2005-07-28   v2    - Changed the params of the constructor and ShowCallstack
+*                       (to simplify the usage)
+*  2005-08-01   v3    - Changed to use 'CONTEXT_FULL' instead of CONTEXT_ALL
+*                       (should also be enough)
+*                     - Changed to compile correctly with the PSDK of VC7.0
+*                       (GetFileVersionInfoSizeA and GetFileVersionInfoA is wrongly defined:
+*                        it uses LPSTR instead of LPCSTR as first parameter)
+*                     - Added declarations to support VC5/6 without using 'dbghelp.h'
+*                     - Added a 'pUserData' member to the ShowCallstack function and the
+*                       PReadProcessMemoryRoutine declaration (to pass some user-defined data,
+*                       which can be used in the readMemoryFunction-callback)
+*  2005-08-02   v4    - OnSymInit now also outputs the OS-Version by default
+*                     - Added example for doing an exception-callstack-walking in main.cpp
+*                       (thanks to owillebo: http://www.codeproject.com/script/profile/whos_who.asp?id=536268)
+*  2005-08-05   v5    - Removed most Lint (http://www.gimpel.com/) errors... thanks to Okko Willeboordse!
+*  2008-08-04   v6    - Fixed Bug: Missing LEAK-end-tag
+*                       http://www.codeproject.com/KB/applications/leakfinder.aspx?msg=2502890#xx2502890xx
+*                       Fixed Bug: Compiled with "WIN32_LEAN_AND_MEAN"
+*                       http://www.codeproject.com/KB/applications/leakfinder.aspx?msg=1824718#xx1824718xx
+*                       Fixed Bug: Compiling with "/Wall"
+*                       http://www.codeproject.com/KB/threads/StackWalker.aspx?msg=2638243#xx2638243xx
+*                       Fixed Bug: Now checking SymUseSymSrv
+*                       http://www.codeproject.com/KB/threads/StackWalker.aspx?msg=1388979#xx1388979xx
+*                       Fixed Bug: Support for recursive function calls
+*                       http://www.codeproject.com/KB/threads/StackWalker.aspx?msg=1434538#xx1434538xx
+*                       Fixed Bug: Missing FreeLibrary call in "GetModuleListTH32"
+*                       http://www.codeproject.com/KB/threads/StackWalker.aspx?msg=1326923#xx1326923xx
+*                       Fixed Bug: SymDia is number 7, not 9!
+*  2008-09-11   v7      For some (undocumented) reason, dbhelp.h is needing a packing of 8!
+*                       Thanks to Teajay which reported the bug...
+*                       http://www.codeproject.com/KB/applications/leakfinder.aspx?msg=2718933#xx2718933xx
+*  2008-11-27   v8      Debugging Tools for Windows are now stored in a different directory
+*                       Thanks to Luiz Salamon which reported this "bug"...
+*                       http://www.codeproject.com/KB/threads/StackWalker.aspx?msg=2822736#xx2822736xx
+*  2009-04-10   v9      License slightly corrected (<ORGANIZATION> replaced)
+*  2009-11-01   v10     Moved to http://stackwalker.codeplex.com/
+*  2009-11-02   v11     Now try to use IMAGEHLP_MODULE64_V3 if available
+*  2010-04-15   v12     Added support for VS2010 RTM
+*  2010-05-25   v13     Now using secure MyStrcCpy. Thanks to luke.simon:
+*                       http://www.codeproject.com/KB/applications/leakfinder.aspx?msg=3477467#xx3477467xx
+*  2013-01-07   v14     Runtime Check Error VS2010 Debug Builds fixed:
+*                       http://stackwalker.codeplex.com/workitem/10511
+*
+*
+* LICENSE (http://www.opensource.org/licenses/bsd-license.php)
+*
+*   Copyright (c) 2005-2013, Jochen Kalmbach
+*   All rights reserved.
+*
+*   Redistribution and use in source and binary forms, with or without modification,
+*   are permitted provided that the following conditions are met:
+*
+*   Redistributions of source code must retain the above copyright notice,
+*   this list of conditions and the following disclaimer.
+*   Redistributions in binary form must reproduce the above copyright notice,
+*   this list of conditions and the following disclaimer in the documentation
+*   and/or other materials provided with the distribution.
+*   Neither the name of Jochen Kalmbach nor the names of its contributors may be
+*   used to endorse or promote products derived from this software without
+*   specific prior written permission.
+*   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+*   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+*   THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+*   ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+*   FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+*   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+*   LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+*   ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+*   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+*   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+**********************************************************************/
 
 #include "StackWalker.h"
 
+#include <stdio.h>
+#include <stdlib.h>
+#include <tchar.h>
+#include <windows.h>
+#pragma comment(lib, "version.lib") // for "VerQueryValue"
+#pragma warning(disable : 4826)
 
 // If VC7 and later, then use the shipped 'dbghelp.h'-file
+#pragma pack(push, 8)
 #if _MSC_VER >= 1300
 #include <dbghelp.h>
 #else
 // inline the important dbghelp.h-declarations...
-typedef enum {
-    SymNone = 0,
-    SymCoff,
-    SymCv,
-    SymPdb,
-    SymExport,
-    SymDeferred,
-    SymSym,
-    SymDia,
-    SymVirtual,
-    NumSymTypes
+typedef enum
+{
+	SymNone = 0,
+	SymCoff,
+	SymCv,
+	SymPdb,
+	SymExport,
+	SymDeferred,
+	SymSym,
+	SymDia,
+	SymVirtual,
+	NumSymTypes
 } SYM_TYPE;
-typedef struct _IMAGEHLP_LINE64 {
-    DWORD                       SizeOfStruct;           // set to sizeof(IMAGEHLP_LINE64)
-    PVOID                       Key;                    // internal
-    DWORD                       LineNumber;             // line number in file
-    PCHAR                       FileName;               // full filename
-    DWORD64                     Address;                // first instruction of line
+typedef struct _IMAGEHLP_LINE64
+{
+	DWORD   SizeOfStruct; // set to sizeof(IMAGEHLP_LINE64)
+	PVOID   Key;          // internal
+	DWORD   LineNumber;   // line number in file
+	PCHAR   FileName;     // full filename
+	DWORD64 Address;      // first instruction of line
 } IMAGEHLP_LINE64, *PIMAGEHLP_LINE64;
-typedef struct _IMAGEHLP_MODULE64 {
-    DWORD                       SizeOfStruct;           // set to sizeof(IMAGEHLP_MODULE64)
-    DWORD64                     BaseOfImage;            // base load address of module
-    DWORD                       ImageSize;              // virtual size of the loaded module
-    DWORD                       TimeDateStamp;          // date/time stamp from pe header
-    DWORD                       CheckSum;               // checksum from the pe header
-    DWORD                       NumSyms;                // number of symbols in the symbol table
-    SYM_TYPE                    SymType;                // type of symbols loaded
-    CHAR                        ModuleName[32];         // module name
-    CHAR                        ImageName[256];         // image name
-    CHAR                        LoadedImageName[256];   // symbol file name
+typedef struct _IMAGEHLP_MODULE64
+{
+	DWORD    SizeOfStruct;         // set to sizeof(IMAGEHLP_MODULE64)
+	DWORD64  BaseOfImage;          // base load address of module
+	DWORD    ImageSize;            // virtual size of the loaded module
+	DWORD    TimeDateStamp;        // date/time stamp from pe header
+	DWORD    CheckSum;             // checksum from the pe header
+	DWORD    NumSyms;              // number of symbols in the symbol table
+	SYM_TYPE SymType;              // type of symbols loaded
+	CHAR     ModuleName[32];       // module name
+	CHAR     ImageName[256];       // image name
+	CHAR     LoadedImageName[256]; // symbol file name
 } IMAGEHLP_MODULE64, *PIMAGEHLP_MODULE64;
-typedef struct _IMAGEHLP_SYMBOL64 {
-    DWORD                       SizeOfStruct;           // set to sizeof(IMAGEHLP_SYMBOL64)
-    DWORD64                     Address;                // virtual address including dll base address
-    DWORD                       Size;                   // estimated size of symbol, can be zero
-    DWORD                       Flags;                  // info about the symbols, see the SYMF defines
-    DWORD                       MaxNameLength;          // maximum size of symbol name in 'Name'
-    CHAR                        Name[1];                // symbol name (null terminated string)
+typedef struct _IMAGEHLP_SYMBOL64
+{
+	DWORD   SizeOfStruct;  // set to sizeof(IMAGEHLP_SYMBOL64)
+	DWORD64 Address;       // virtual address including dll base address
+	DWORD   Size;          // estimated size of symbol, can be zero
+	DWORD   Flags;         // info about the symbols, see the SYMF defines
+	DWORD   MaxNameLength; // maximum size of symbol name in 'Name'
+	CHAR    Name[1];       // symbol name (null terminated string)
 } IMAGEHLP_SYMBOL64, *PIMAGEHLP_SYMBOL64;
-typedef enum {
-    AddrMode1616,
-    AddrMode1632,
-    AddrModeReal,
-    AddrModeFlat
+typedef enum
+{
+	AddrMode1616,
+	AddrMode1632,
+	AddrModeReal,
+	AddrModeFlat
 } ADDRESS_MODE;
-typedef struct _tagADDRESS64 {
-    DWORD64       Offset;
-    WORD          Segment;
-    ADDRESS_MODE  Mode;
+typedef struct _tagADDRESS64
+{
+	DWORD64      Offset;
+	WORD         Segment;
+	ADDRESS_MODE Mode;
 } ADDRESS64, *LPADDRESS64;
-typedef struct _KDHELP64 {
-    DWORD64   Thread;
-    DWORD   ThCallbackStack;
-    DWORD   ThCallbackBStore;
-    DWORD   NextCallback;
-    DWORD   FramePointer;
-    DWORD64   KiCallUserMode;
-    DWORD64   KeUserCallbackDispatcher;
-    DWORD64   SystemRangeStart;
-    DWORD64  Reserved[8];
+typedef struct _KDHELP64
+{
+	DWORD64 Thread;
+	DWORD   ThCallbackStack;
+	DWORD   ThCallbackBStore;
+	DWORD   NextCallback;
+	DWORD   FramePointer;
+	DWORD64 KiCallUserMode;
+	DWORD64 KeUserCallbackDispatcher;
+	DWORD64 SystemRangeStart;
+	DWORD64 Reserved[8];
 } KDHELP64, *PKDHELP64;
-typedef struct _tagSTACKFRAME64 {
-    ADDRESS64   AddrPC;               // program counter
-    ADDRESS64   AddrReturn;           // return address
-    ADDRESS64   AddrFrame;            // frame pointer
-    ADDRESS64   AddrStack;            // stack pointer
-    ADDRESS64   AddrBStore;           // backing store pointer
-    PVOID       FuncTableEntry;       // pointer to pdata/fpo or NULL
-    DWORD64     Params[4];            // possible arguments to the function
-    BOOL        Far;                  // WOW far call
-    BOOL        Virtual;              // is this a virtual frame?
-    DWORD64     Reserved[3];
-    KDHELP64    KdHelp;
+typedef struct _tagSTACKFRAME64
+{
+	ADDRESS64 AddrPC;         // program counter
+	ADDRESS64 AddrReturn;     // return address
+	ADDRESS64 AddrFrame;      // frame pointer
+	ADDRESS64 AddrStack;      // stack pointer
+	ADDRESS64 AddrBStore;     // backing store pointer
+	PVOID     FuncTableEntry; // pointer to pdata/fpo or NULL
+	DWORD64   Params[4];      // possible arguments to the function
+	BOOL      Far;            // WOW far call
+	BOOL      Virtual;        // is this a virtual frame?
+	DWORD64   Reserved[3];
+	KDHELP64  KdHelp;
 } STACKFRAME64, *LPSTACKFRAME64;
-typedef
-BOOL
-(__stdcall *PREAD_PROCESS_MEMORY_ROUTINE64)(
-    HANDLE      hProcess,
-    DWORD64     qwBaseAddress,
-    PVOID       lpBuffer,
-    DWORD       nSize,
-    LPDWORD     lpNumberOfBytesRead
-    );
-typedef
-PVOID
-(__stdcall *PFUNCTION_TABLE_ACCESS_ROUTINE64)(
-    HANDLE  hProcess,
-    DWORD64 AddrBase
-    );
-typedef
-DWORD64
-(__stdcall *PGET_MODULE_BASE_ROUTINE64)(
-    HANDLE  hProcess,
-    DWORD64 Address
-    );
-typedef
-DWORD64
-(__stdcall *PTRANSLATE_ADDRESS_ROUTINE64)(
-    HANDLE    hProcess,
-    HANDLE    hThread,
-    LPADDRESS64 lpaddr
-    );
+typedef BOOL(__stdcall* PREAD_PROCESS_MEMORY_ROUTINE64)(HANDLE  hProcess,
+	DWORD64 qwBaseAddress,
+	PVOID   lpBuffer,
+	DWORD   nSize,
+	LPDWORD lpNumberOfBytesRead);
+typedef PVOID(__stdcall* PFUNCTION_TABLE_ACCESS_ROUTINE64)(HANDLE hProcess, DWORD64 AddrBase);
+typedef DWORD64(__stdcall* PGET_MODULE_BASE_ROUTINE64)(HANDLE hProcess, DWORD64 Address);
+typedef DWORD64(__stdcall* PTRANSLATE_ADDRESS_ROUTINE64)(HANDLE      hProcess,
+	HANDLE      hThread,
+	LPADDRESS64 lpaddr);
+
+// clang-format off
 #define SYMOPT_CASE_INSENSITIVE         0x00000001
 #define SYMOPT_UNDNAME                  0x00000002
 #define SYMOPT_DEFERRED_LOADS           0x00000004
@@ -158,1063 +211,1258 @@ DWORD64
 #define SYMOPT_NO_IMAGE_SEARCH          0x00020000
 #define SYMOPT_SECURE                   0x00040000
 #define SYMOPT_DEBUG                    0x80000000
-#define UNDNAME_COMPLETE                 (0x0000)  // Enable full undecoration
-#define UNDNAME_NAME_ONLY                (0x1000)  // Crack only the name for primary declaration;
-#endif  // _MSC_VER < 1300
+#define UNDNAME_COMPLETE                 (0x0000) // Enable full undecoration
+#define UNDNAME_NAME_ONLY                (0x1000) // Crack only the name for primary declaration;
+// clang-format on
+
+#endif // _MSC_VER < 1300
+#pragma pack(pop)
 
 // Some missing defines (for VC5/6):
 #ifndef INVALID_FILE_ATTRIBUTES
 #define INVALID_FILE_ATTRIBUTES ((DWORD)-1)
-#endif  
-
+#endif
 
 // secure-CRT_functions are only available starting with VC8
 #if _MSC_VER < 1400
-#define strcpy_s strcpy
+#define strcpy_s(dst, len, src) strcpy(dst, src)
+#define strncpy_s(dst, len, src, maxLen) strncpy(dst, len, src)
 #define strcat_s(dst, len, src) strcat(dst, src)
 #define _snprintf_s _snprintf
 #define _tcscat_s _tcscat
 #endif
 
-// Normally it should be enough to use 'CONTEXT_FULL' (better would be 'CONTEXT_ALL')
-#define USED_CONTEXT_FLAGS CONTEXT_FULL
+static void MyStrCpy(char* szDest, size_t nMaxDestSize, const char* szSrc)
+{
+	if (nMaxDestSize <= 0)
+		return;
+	strncpy_s(szDest, nMaxDestSize, szSrc, _TRUNCATE);
+	// INFO: _TRUNCATE will ensure that it is null-terminated;
+	// but with older compilers (<1400) it uses "strncpy" and this does not!)
+	szDest[nMaxDestSize - 1] = 0;
+} // MyStrCpy
 
+  // Normally it should be enough to use 'CONTEXT_FULL' (better would be 'CONTEXT_ALL')
+#define USED_CONTEXT_FLAGS CONTEXT_FULL
 
 class StackWalkerInternal
 {
 public:
-  StackWalkerInternal(StackWalker *parent, HANDLE hProcess)
-  {
-    m_parent = parent;
-    m_hDbhHelp = NULL;
-    pSC = NULL;
-    m_hProcess = hProcess;
-    m_szSymPath = NULL;
-    pSFTA = NULL;
-    pSGLFA = NULL;
-    pSGMB = NULL;
-    pSGMI = NULL;
-    pSGO = NULL;
-    pSGSFA = NULL;
-    pSI = NULL;
-    pSLM = NULL;
-    pSSO = NULL;
-    pSW = NULL;
-    pUDSN = NULL;
-    pSGSP = NULL;
-  }
-  ~StackWalkerInternal()
-  {
-    if (pSC != NULL)
-      pSC(m_hProcess);  // SymCleanup
-    if (m_hDbhHelp != NULL)
-      FreeLibrary(m_hDbhHelp);
-    m_hDbhHelp = NULL;
-    m_parent = NULL;
-    if(m_szSymPath != NULL)
-      free(m_szSymPath);
-    m_szSymPath = NULL;
-  }
-  BOOL Init(LPCSTR szSymPath)
-  {
-    if (m_parent == NULL)
-      return FALSE;
-    // Dynamically load the Entry-Points for dbghelp.dll:
-    // First try to load the newsest one from
-    TCHAR szTemp[4096];
-    // But before wqe do this, we first check if the ".local" file exists
-    if (GetModuleFileName(NULL, szTemp, 4096) > 0)
-    {
-      _tcscat_s(szTemp, _T(".local"));
-      if (GetFileAttributes(szTemp) == INVALID_FILE_ATTRIBUTES)
-      {
-        // ".local" file does not exist, so we can try to load the dbghelp.dll from the "Debugging Tools for Windows"
-        if (GetEnvironmentVariable(_T("ProgramFiles"), szTemp, 4096) > 0)
-        {
-          _tcscat_s(szTemp, _T("\\Debugging Tools for Windows\\dbghelp.dll"));
-          // now check if the file exists:
-          if (GetFileAttributes(szTemp) != INVALID_FILE_ATTRIBUTES)
-          {
-            m_hDbhHelp = LoadLibrary(szTemp);
-          }
-        }
-          // Still not found? Then try to load the 64-Bit version:
-        if ( (m_hDbhHelp == NULL) && (GetEnvironmentVariable(_T("ProgramFiles"), szTemp, 4096) > 0) )
-        {
-          _tcscat_s(szTemp, _T("\\Debugging Tools for Windows 64-Bit\\dbghelp.dll"));
-          if (GetFileAttributes(szTemp) != INVALID_FILE_ATTRIBUTES)
-          {
-            m_hDbhHelp = LoadLibrary(szTemp);
-          }
-        }
-      }
-    }
-    if (m_hDbhHelp == NULL)  // if not already loaded, try to load a default-one
-      m_hDbhHelp = LoadLibrary( _T("dbghelp.dll") );
-    if (m_hDbhHelp == NULL)
-      return FALSE;
-    pSI = (tSI) GetProcAddress(m_hDbhHelp, "SymInitialize" );
-    pSC = (tSC) GetProcAddress(m_hDbhHelp, "SymCleanup" );
+	StackWalkerInternal(StackWalker* parent, HANDLE hProcess)
+	{
+		m_parent = parent;
+		m_hDbhHelp = NULL;
+		pSC = NULL;
+		m_hProcess = hProcess;
+		m_szSymPath = NULL;
+		pSFTA = NULL;
+		pSGLFA = NULL;
+		pSGMB = NULL;
+		pSGMI = NULL;
+		pSGO = NULL;
+		pSGSFA = NULL;
+		pSI = NULL;
+		pSLM = NULL;
+		pSSO = NULL;
+		pSW = NULL;
+		pUDSN = NULL;
+		pSGSP = NULL;
+	}
+	~StackWalkerInternal()
+	{
+		if (pSC != NULL)
+			pSC(m_hProcess); // SymCleanup
+		if (m_hDbhHelp != NULL)
+			FreeLibrary(m_hDbhHelp);
+		m_hDbhHelp = NULL;
+		m_parent = NULL;
+		if (m_szSymPath != NULL)
+			free(m_szSymPath);
+		m_szSymPath = NULL;
+	}
+	BOOL Init(LPCSTR szSymPath)
+	{
+		if (m_parent == NULL)
+			return FALSE;
+		// Dynamically load the Entry-Points for dbghelp.dll:
+		// First try to load the newest one from
+		TCHAR szTemp[4096];
+		// But before we do this, we first check if the ".local" file exists
+		if (GetModuleFileName(NULL, szTemp, 4096) > 0)
+		{
+			_tcscat_s(szTemp, _T(".local"));
+			if (GetFileAttributes(szTemp) == INVALID_FILE_ATTRIBUTES)
+			{
+				// ".local" file does not exist, so we can try to load the dbghelp.dll from the "Debugging Tools for Windows"
+				// Ok, first try the new path according to the architecture:
+#ifdef _M_IX86
+				if ((m_hDbhHelp == NULL) && (GetEnvironmentVariable(_T("ProgramFiles"), szTemp, 4096) > 0))
+				{
+					_tcscat_s(szTemp, _T("\\Debugging Tools for Windows (x86)\\dbghelp.dll"));
+					// now check if the file exists:
+					if (GetFileAttributes(szTemp) != INVALID_FILE_ATTRIBUTES)
+					{
+						m_hDbhHelp = LoadLibrary(szTemp);
+					}
+				}
+#elif _M_X64
+				if ((m_hDbhHelp == NULL) && (GetEnvironmentVariable(_T("ProgramFiles"), szTemp, 4096) > 0))
+				{
+					_tcscat_s(szTemp, _T("\\Debugging Tools for Windows (x64)\\dbghelp.dll"));
+					// now check if the file exists:
+					if (GetFileAttributes(szTemp) != INVALID_FILE_ATTRIBUTES)
+					{
+						m_hDbhHelp = LoadLibrary(szTemp);
+					}
+				}
+#elif _M_IA64
+				if ((m_hDbhHelp == NULL) && (GetEnvironmentVariable(_T("ProgramFiles"), szTemp, 4096) > 0))
+				{
+					_tcscat_s(szTemp, _T("\\Debugging Tools for Windows (ia64)\\dbghelp.dll"));
+					// now check if the file exists:
+					if (GetFileAttributes(szTemp) != INVALID_FILE_ATTRIBUTES)
+					{
+						m_hDbhHelp = LoadLibrary(szTemp);
+					}
+				}
+#endif
+				// If still not found, try the old directories...
+				if ((m_hDbhHelp == NULL) && (GetEnvironmentVariable(_T("ProgramFiles"), szTemp, 4096) > 0))
+				{
+					_tcscat_s(szTemp, _T("\\Debugging Tools for Windows\\dbghelp.dll"));
+					// now check if the file exists:
+					if (GetFileAttributes(szTemp) != INVALID_FILE_ATTRIBUTES)
+					{
+						m_hDbhHelp = LoadLibrary(szTemp);
+					}
+				}
+#if defined _M_X64 || defined _M_IA64
+				// Still not found? Then try to load the (old) 64-Bit version:
+				if ((m_hDbhHelp == NULL) && (GetEnvironmentVariable(_T("ProgramFiles"), szTemp, 4096) > 0))
+				{
+					_tcscat_s(szTemp, _T("\\Debugging Tools for Windows 64-Bit\\dbghelp.dll"));
+					if (GetFileAttributes(szTemp) != INVALID_FILE_ATTRIBUTES)
+					{
+						m_hDbhHelp = LoadLibrary(szTemp);
+					}
+				}
+#endif
+			}
+		}
+		if (m_hDbhHelp == NULL) // if not already loaded, try to load a default-one
+			m_hDbhHelp = LoadLibrary(_T("dbghelp.dll"));
+		if (m_hDbhHelp == NULL)
+			return FALSE;
+		pSI = (tSI)GetProcAddress(m_hDbhHelp, "SymInitialize");
+		pSC = (tSC)GetProcAddress(m_hDbhHelp, "SymCleanup");
 
-    pSW = (tSW) GetProcAddress(m_hDbhHelp, "StackWalk64" );
-    pSGO = (tSGO) GetProcAddress(m_hDbhHelp, "SymGetOptions" );
-    pSSO = (tSSO) GetProcAddress(m_hDbhHelp, "SymSetOptions" );
+		pSW = (tSW)GetProcAddress(m_hDbhHelp, "StackWalk64");
+		pSGO = (tSGO)GetProcAddress(m_hDbhHelp, "SymGetOptions");
+		pSSO = (tSSO)GetProcAddress(m_hDbhHelp, "SymSetOptions");
 
-    pSFTA = (tSFTA) GetProcAddress(m_hDbhHelp, "SymFunctionTableAccess64" );
-    pSGLFA = (tSGLFA) GetProcAddress(m_hDbhHelp, "SymGetLineFromAddr64" );
-    pSGMB = (tSGMB) GetProcAddress(m_hDbhHelp, "SymGetModuleBase64" );
-    pSGMI = (tSGMI) GetProcAddress(m_hDbhHelp, "SymGetModuleInfo64" );
-    //pSGMI_V3 = (tSGMI_V3) GetProcAddress(m_hDbhHelp, "SymGetModuleInfo64" );
-    pSGSFA = (tSGSFA) GetProcAddress(m_hDbhHelp, "SymGetSymFromAddr64" );
-    pUDSN = (tUDSN) GetProcAddress(m_hDbhHelp, "UnDecorateSymbolName" );
-    pSLM = (tSLM) GetProcAddress(m_hDbhHelp, "SymLoadModule64" );
-    pSGSP =(tSGSP) GetProcAddress(m_hDbhHelp, "SymGetSearchPath" );
+		pSFTA = (tSFTA)GetProcAddress(m_hDbhHelp, "SymFunctionTableAccess64");
+		pSGLFA = (tSGLFA)GetProcAddress(m_hDbhHelp, "SymGetLineFromAddr64");
+		pSGMB = (tSGMB)GetProcAddress(m_hDbhHelp, "SymGetModuleBase64");
+		pSGMI = (tSGMI)GetProcAddress(m_hDbhHelp, "SymGetModuleInfo64");
+		pSGSFA = (tSGSFA)GetProcAddress(m_hDbhHelp, "SymGetSymFromAddr64");
+		pUDSN = (tUDSN)GetProcAddress(m_hDbhHelp, "UnDecorateSymbolName");
+		pSLM = (tSLM)GetProcAddress(m_hDbhHelp, "SymLoadModule64");
+		pSGSP = (tSGSP)GetProcAddress(m_hDbhHelp, "SymGetSearchPath");
 
-    if ( pSC == NULL || pSFTA == NULL || pSGMB == NULL || pSGMI == NULL ||
-      pSGO == NULL || pSGSFA == NULL || pSI == NULL || pSSO == NULL ||
-      pSW == NULL || pUDSN == NULL || pSLM == NULL )
-    {
-      FreeLibrary(m_hDbhHelp);
-      m_hDbhHelp = NULL;
-      pSC = NULL;
-      return FALSE;
-    }
+		if (pSC == NULL || pSFTA == NULL || pSGMB == NULL || pSGMI == NULL || pSGO == NULL ||
+			pSGSFA == NULL || pSI == NULL || pSSO == NULL || pSW == NULL || pUDSN == NULL ||
+			pSLM == NULL)
+		{
+			FreeLibrary(m_hDbhHelp);
+			m_hDbhHelp = NULL;
+			pSC = NULL;
+			return FALSE;
+		}
 
-    // SymInitialize
-    if (szSymPath != NULL)
-      m_szSymPath = _strdup(szSymPath);
-    if (this->pSI(m_hProcess, m_szSymPath, FALSE) == FALSE)
-      this->m_parent->OnDbgHelpErr("SymInitialize", GetLastError(), 0);
-      
-    DWORD symOptions = this->pSGO();  // SymGetOptions
-    symOptions |= SYMOPT_LOAD_LINES;
-    symOptions |= SYMOPT_FAIL_CRITICAL_ERRORS;
-    //symOptions |= SYMOPT_NO_PROMPTS;
-    // SymSetOptions
-    symOptions = this->pSSO(symOptions);
+		// SymInitialize
+		if (szSymPath != NULL)
+			m_szSymPath = _strdup(szSymPath);
+		if (this->pSI(m_hProcess, m_szSymPath, FALSE) == FALSE)
+			this->m_parent->OnDbgHelpErr("SymInitialize", GetLastError(), 0);
 
-    char buf[StackWalker::STACKWALK_MAX_NAMELEN] = {0};
-    if (this->pSGSP != NULL)
-    {
-      if (this->pSGSP(m_hProcess, buf, StackWalker::STACKWALK_MAX_NAMELEN) == FALSE)
-        this->m_parent->OnDbgHelpErr("SymGetSearchPath", GetLastError(), 0);
-    }
-    char szUserName[1024] = {0};
-    DWORD dwSize = 1024;
-    GetUserNameA(szUserName, &dwSize);
-    this->m_parent->OnSymInit(buf, symOptions, szUserName);
+		DWORD symOptions = this->pSGO(); // SymGetOptions
+		symOptions |= SYMOPT_LOAD_LINES;
+		symOptions |= SYMOPT_FAIL_CRITICAL_ERRORS;
+		//symOptions |= SYMOPT_NO_PROMPTS;
+		// SymSetOptions
+		symOptions = this->pSSO(symOptions);
 
-    return TRUE;
-  }
+		char buf[StackWalker::STACKWALK_MAX_NAMELEN] = { 0 };
+		if (this->pSGSP != NULL)
+		{
+			if (this->pSGSP(m_hProcess, buf, StackWalker::STACKWALK_MAX_NAMELEN) == FALSE)
+				this->m_parent->OnDbgHelpErr("SymGetSearchPath", GetLastError(), 0);
+		}
+		char  szUserName[1024] = { 0 };
+		DWORD dwSize = 1024;
+		GetUserNameA(szUserName, &dwSize);
+		this->m_parent->OnSymInit(buf, symOptions, szUserName);
 
-  StackWalker *m_parent;
+		return TRUE;
+	}
 
-  HMODULE m_hDbhHelp;
-  HANDLE m_hProcess;
-  LPSTR m_szSymPath;
+	StackWalker* m_parent;
 
-/*typedef struct IMAGEHLP_MODULE64_V3 {
-    DWORD    SizeOfStruct;           // set to sizeof(IMAGEHLP_MODULE64)
-    DWORD64  BaseOfImage;            // base load address of module
-    DWORD    ImageSize;              // virtual size of the loaded module
-    DWORD    TimeDateStamp;          // date/time stamp from pe header
-    DWORD    CheckSum;               // checksum from the pe header
-    DWORD    NumSyms;                // number of symbols in the symbol table
-    SYM_TYPE SymType;                // type of symbols loaded
-    CHAR     ModuleName[32];         // module name
-    CHAR     ImageName[256];         // image name
-    // new elements: 07-Jun-2002
-    CHAR     LoadedImageName[256];   // symbol file name
-    CHAR     LoadedPdbName[256];     // pdb file name
-    DWORD    CVSig;                  // Signature of the CV record in the debug directories
-    CHAR         CVData[MAX_PATH * 3];   // Contents of the CV record
-    DWORD    PdbSig;                 // Signature of PDB
-    GUID     PdbSig70;               // Signature of PDB (VC 7 and up)
-    DWORD    PdbAge;                 // DBI age of pdb
-    BOOL     PdbUnmatched;           // loaded an unmatched pdb
-    BOOL     DbgUnmatched;           // loaded an unmatched dbg
-    BOOL     LineNumbers;            // we have line number information
-    BOOL     GlobalSymbols;          // we have internal symbol information
-    BOOL     TypeInfo;               // we have type information
-    // new elements: 17-Dec-2003
-    BOOL     SourceIndexed;          // pdb supports source server
-    BOOL     Publics;                // contains public symbols
-};
-*/
-typedef struct IMAGEHLP_MODULE64_V2 {
-    DWORD    SizeOfStruct;           // set to sizeof(IMAGEHLP_MODULE64)
-    DWORD64  BaseOfImage;            // base load address of module
-    DWORD    ImageSize;              // virtual size of the loaded module
-    DWORD    TimeDateStamp;          // date/time stamp from pe header
-    DWORD    CheckSum;               // checksum from the pe header
-    DWORD    NumSyms;                // number of symbols in the symbol table
-    SYM_TYPE SymType;                // type of symbols loaded
-    CHAR     ModuleName[32];         // module name
-    CHAR     ImageName[256];         // image name
-    CHAR     LoadedImageName[256];   // symbol file name
-};
+	HMODULE m_hDbhHelp;
+	HANDLE  m_hProcess;
+	LPSTR   m_szSymPath;
 
+#pragma pack(push, 8)
+	typedef struct IMAGEHLP_MODULE64_V3
+	{
+		DWORD    SizeOfStruct;         // set to sizeof(IMAGEHLP_MODULE64)
+		DWORD64  BaseOfImage;          // base load address of module
+		DWORD    ImageSize;            // virtual size of the loaded module
+		DWORD    TimeDateStamp;        // date/time stamp from pe header
+		DWORD    CheckSum;             // checksum from the pe header
+		DWORD    NumSyms;              // number of symbols in the symbol table
+		SYM_TYPE SymType;              // type of symbols loaded
+		CHAR     ModuleName[32];       // module name
+		CHAR     ImageName[256];       // image name
+		CHAR     LoadedImageName[256]; // symbol file name
+									   // new elements: 07-Jun-2002
+		CHAR  LoadedPdbName[256];   // pdb file name
+		DWORD CVSig;                // Signature of the CV record in the debug directories
+		CHAR  CVData[MAX_PATH * 3]; // Contents of the CV record
+		DWORD PdbSig;               // Signature of PDB
+		GUID  PdbSig70;             // Signature of PDB (VC 7 and up)
+		DWORD PdbAge;               // DBI age of pdb
+		BOOL  PdbUnmatched;         // loaded an unmatched pdb
+		BOOL  DbgUnmatched;         // loaded an unmatched dbg
+		BOOL  LineNumbers;          // we have line number information
+		BOOL  GlobalSymbols;        // we have internal symbol information
+		BOOL  TypeInfo;             // we have type information
+									// new elements: 17-Dec-2003
+		BOOL SourceIndexed; // pdb supports source server
+		BOOL Publics;       // contains public symbols
+	};
 
-  // SymCleanup()
-  typedef BOOL (__stdcall *tSC)( IN HANDLE hProcess );
-  tSC pSC;
+	typedef struct IMAGEHLP_MODULE64_V2
+	{
+		DWORD    SizeOfStruct;         // set to sizeof(IMAGEHLP_MODULE64)
+		DWORD64  BaseOfImage;          // base load address of module
+		DWORD    ImageSize;            // virtual size of the loaded module
+		DWORD    TimeDateStamp;        // date/time stamp from pe header
+		DWORD    CheckSum;             // checksum from the pe header
+		DWORD    NumSyms;              // number of symbols in the symbol table
+		SYM_TYPE SymType;              // type of symbols loaded
+		CHAR     ModuleName[32];       // module name
+		CHAR     ImageName[256];       // image name
+		CHAR     LoadedImageName[256]; // symbol file name
+	};
+#pragma pack(pop)
 
-  // SymFunctionTableAccess64()
-  typedef PVOID (__stdcall *tSFTA)( HANDLE hProcess, DWORD64 AddrBase );
-  tSFTA pSFTA;
+	// SymCleanup()
+	typedef BOOL(__stdcall* tSC)(IN HANDLE hProcess);
+	tSC pSC;
 
-  // SymGetLineFromAddr64()
-  typedef BOOL (__stdcall *tSGLFA)( IN HANDLE hProcess, IN DWORD64 dwAddr,
-    OUT PDWORD pdwDisplacement, OUT PIMAGEHLP_LINE64 Line );
-  tSGLFA pSGLFA;
+	// SymFunctionTableAccess64()
+	typedef PVOID(__stdcall* tSFTA)(HANDLE hProcess, DWORD64 AddrBase);
+	tSFTA pSFTA;
 
-  // SymGetModuleBase64()
-  typedef DWORD64 (__stdcall *tSGMB)( IN HANDLE hProcess, IN DWORD64 dwAddr );
-  tSGMB pSGMB;
+	// SymGetLineFromAddr64()
+	typedef BOOL(__stdcall* tSGLFA)(IN HANDLE hProcess,
+		IN DWORD64 dwAddr,
+		OUT PDWORD pdwDisplacement,
+		OUT PIMAGEHLP_LINE64 Line);
+	tSGLFA pSGLFA;
 
-  // SymGetModuleInfo64()
-  typedef BOOL (__stdcall *tSGMI)( IN HANDLE hProcess, IN DWORD64 dwAddr, OUT IMAGEHLP_MODULE64_V2 *ModuleInfo );
-  tSGMI pSGMI;
+	// SymGetModuleBase64()
+	typedef DWORD64(__stdcall* tSGMB)(IN HANDLE hProcess, IN DWORD64 dwAddr);
+	tSGMB pSGMB;
 
-//  // SymGetModuleInfo64()
-//  typedef BOOL (__stdcall *tSGMI_V3)( IN HANDLE hProcess, IN DWORD64 dwAddr, OUT IMAGEHLP_MODULE64_V3 *ModuleInfo );
-//  tSGMI_V3 pSGMI_V3;
+	// SymGetModuleInfo64()
+	typedef BOOL(__stdcall* tSGMI)(IN HANDLE hProcess,
+		IN DWORD64 dwAddr,
+		OUT IMAGEHLP_MODULE64_V3* ModuleInfo);
+	tSGMI pSGMI;
 
-  // SymGetOptions()
-  typedef DWORD (__stdcall *tSGO)( VOID );
-  tSGO pSGO;
+	// SymGetOptions()
+	typedef DWORD(__stdcall* tSGO)(VOID);
+	tSGO pSGO;
 
-  // SymGetSymFromAddr64()
-  typedef BOOL (__stdcall *tSGSFA)( IN HANDLE hProcess, IN DWORD64 dwAddr,
-    OUT PDWORD64 pdwDisplacement, OUT PIMAGEHLP_SYMBOL64 Symbol );
-  tSGSFA pSGSFA;
+	// SymGetSymFromAddr64()
+	typedef BOOL(__stdcall* tSGSFA)(IN HANDLE hProcess,
+		IN DWORD64 dwAddr,
+		OUT PDWORD64 pdwDisplacement,
+		OUT PIMAGEHLP_SYMBOL64 Symbol);
+	tSGSFA pSGSFA;
 
-  // SymInitialize()
-  typedef BOOL (__stdcall *tSI)( IN HANDLE hProcess, IN PSTR UserSearchPath, IN BOOL fInvadeProcess );
-  tSI pSI;
+	// SymInitialize()
+	typedef BOOL(__stdcall* tSI)(IN HANDLE hProcess, IN PSTR UserSearchPath, IN BOOL fInvadeProcess);
+	tSI pSI;
 
-  // SymLoadModule64()
-  typedef DWORD64 (__stdcall *tSLM)( IN HANDLE hProcess, IN HANDLE hFile,
-    IN PSTR ImageName, IN PSTR ModuleName, IN DWORD64 BaseOfDll, IN DWORD SizeOfDll );
-  tSLM pSLM;
+	// SymLoadModule64()
+	typedef DWORD64(__stdcall* tSLM)(IN HANDLE hProcess,
+		IN HANDLE hFile,
+		IN PSTR ImageName,
+		IN PSTR ModuleName,
+		IN DWORD64 BaseOfDll,
+		IN DWORD SizeOfDll);
+	tSLM pSLM;
 
-  // SymSetOptions()
-  typedef DWORD (__stdcall *tSSO)( IN DWORD SymOptions );
-  tSSO pSSO;
+	// SymSetOptions()
+	typedef DWORD(__stdcall* tSSO)(IN DWORD SymOptions);
+	tSSO pSSO;
 
-  // StackWalk64()
-  typedef BOOL (__stdcall *tSW)( 
-    DWORD MachineType, 
-    HANDLE hProcess,
-    HANDLE hThread, 
-    LPSTACKFRAME64 StackFrame, 
-    PVOID ContextRecord,
-    PREAD_PROCESS_MEMORY_ROUTINE64 ReadMemoryRoutine,
-    PFUNCTION_TABLE_ACCESS_ROUTINE64 FunctionTableAccessRoutine,
-    PGET_MODULE_BASE_ROUTINE64 GetModuleBaseRoutine,
-    PTRANSLATE_ADDRESS_ROUTINE64 TranslateAddress );
-  tSW pSW;
+	// StackWalk64()
+	typedef BOOL(__stdcall* tSW)(DWORD                            MachineType,
+		HANDLE                           hProcess,
+		HANDLE                           hThread,
+		LPSTACKFRAME64                   StackFrame,
+		PVOID                            ContextRecord,
+		PREAD_PROCESS_MEMORY_ROUTINE64   ReadMemoryRoutine,
+		PFUNCTION_TABLE_ACCESS_ROUTINE64 FunctionTableAccessRoutine,
+		PGET_MODULE_BASE_ROUTINE64       GetModuleBaseRoutine,
+		PTRANSLATE_ADDRESS_ROUTINE64     TranslateAddress);
+	tSW pSW;
 
-  // UnDecorateSymbolName()
-  typedef DWORD (__stdcall WINAPI *tUDSN)( PCSTR DecoratedName, PSTR UnDecoratedName,
-    DWORD UndecoratedLength, DWORD Flags );
-  tUDSN pUDSN;
+	// UnDecorateSymbolName()
+	typedef DWORD(__stdcall WINAPI* tUDSN)(PCSTR DecoratedName,
+		PSTR  UnDecoratedName,
+		DWORD UndecoratedLength,
+		DWORD Flags);
+	tUDSN pUDSN;
 
-  typedef BOOL (__stdcall WINAPI *tSGSP)(HANDLE hProcess, PSTR SearchPath, DWORD SearchPathLength);
-  tSGSP pSGSP;
-
+	typedef BOOL(__stdcall WINAPI* tSGSP)(HANDLE hProcess, PSTR SearchPath, DWORD SearchPathLength);
+	tSGSP pSGSP;
 
 private:
-  // **************************************** ToolHelp32 ************************
-  #define MAX_MODULE_NAME32 255
-  #define TH32CS_SNAPMODULE   0x00000008
-  #pragma pack( push, 8 )
-  typedef struct tagMODULEENTRY32
-  {
-      DWORD   dwSize;
-      DWORD   th32ModuleID;       // This module
-      DWORD   th32ProcessID;      // owning process
-      DWORD   GlblcntUsage;       // Global usage count on the module
-      DWORD   ProccntUsage;       // Module usage count in th32ProcessID's context
-      BYTE  * modBaseAddr;        // Base address of module in th32ProcessID's context
-      DWORD   modBaseSize;        // Size in bytes of module starting at modBaseAddr
-      HMODULE hModule;            // The hModule of this module in th32ProcessID's context
-      char    szModule[MAX_MODULE_NAME32 + 1];
-      char    szExePath[MAX_PATH];
-  } MODULEENTRY32;
-  typedef MODULEENTRY32 *  PMODULEENTRY32;
-  typedef MODULEENTRY32 *  LPMODULEENTRY32;
-  #pragma pack( pop )
+	// **************************************** ToolHelp32 ************************
+#define MAX_MODULE_NAME32 255
+#define TH32CS_SNAPMODULE 0x00000008
+#pragma pack(push, 8)
+	typedef struct tagMODULEENTRY32
+	{
+		DWORD   dwSize;
+		DWORD   th32ModuleID;  // This module
+		DWORD   th32ProcessID; // owning process
+		DWORD   GlblcntUsage;  // Global usage count on the module
+		DWORD   ProccntUsage;  // Module usage count in th32ProcessID's context
+		BYTE*   modBaseAddr;   // Base address of module in th32ProcessID's context
+		DWORD   modBaseSize;   // Size in bytes of module starting at modBaseAddr
+		HMODULE hModule;       // The hModule of this module in th32ProcessID's context
+		char    szModule[MAX_MODULE_NAME32 + 1];
+		char    szExePath[MAX_PATH];
+	} MODULEENTRY32;
+	typedef MODULEENTRY32* PMODULEENTRY32;
+	typedef MODULEENTRY32* LPMODULEENTRY32;
+#pragma pack(pop)
 
-  BOOL GetModuleListTH32(HANDLE hProcess, DWORD pid)
-  {
-    // CreateToolhelp32Snapshot()
-    typedef HANDLE (__stdcall *tCT32S)(DWORD dwFlags, DWORD th32ProcessID);
-    // Module32First()
-    typedef BOOL (__stdcall *tM32F)(HANDLE hSnapshot, LPMODULEENTRY32 lpme);
-    // Module32Next()
-    typedef BOOL (__stdcall *tM32N)(HANDLE hSnapshot, LPMODULEENTRY32 lpme);
+	BOOL GetModuleListTH32(HANDLE hProcess, DWORD pid)
+	{
+		// CreateToolhelp32Snapshot()
+		typedef HANDLE(__stdcall * tCT32S)(DWORD dwFlags, DWORD th32ProcessID);
+		// Module32First()
+		typedef BOOL(__stdcall * tM32F)(HANDLE hSnapshot, LPMODULEENTRY32 lpme);
+		// Module32Next()
+		typedef BOOL(__stdcall * tM32N)(HANDLE hSnapshot, LPMODULEENTRY32 lpme);
 
-    // try both dlls...
-    const TCHAR *dllname[] = { _T("kernel32.dll"), _T("tlhelp32.dll") };
-    HINSTANCE hToolhelp = NULL;
-    tCT32S pCT32S = NULL;
-    tM32F pM32F = NULL;
-    tM32N pM32N = NULL;
+		// try both dlls...
+		const TCHAR* dllname[] = { _T("kernel32.dll"), _T("tlhelp32.dll") };
+		HINSTANCE    hToolhelp = NULL;
+		tCT32S       pCT32S = NULL;
+		tM32F        pM32F = NULL;
+		tM32N        pM32N = NULL;
 
-    HANDLE hSnap;
-    MODULEENTRY32 me;
-    me.dwSize = sizeof(me);
-    BOOL keepGoing;
-    size_t i;
+		HANDLE        hSnap;
+		MODULEENTRY32 me;
+		me.dwSize = sizeof(me);
+		BOOL   keepGoing;
+		size_t i;
 
-    for (i = 0; i<(sizeof(dllname) / sizeof(dllname[0])); i++ )
-    {
-      hToolhelp = LoadLibrary( dllname[i] );
-      if (hToolhelp == NULL)
-        continue;
-      pCT32S = (tCT32S) GetProcAddress(hToolhelp, "CreateToolhelp32Snapshot");
-      pM32F = (tM32F) GetProcAddress(hToolhelp, "Module32First");
-      pM32N = (tM32N) GetProcAddress(hToolhelp, "Module32Next");
-      if ( (pCT32S != NULL) && (pM32F != NULL) && (pM32N != NULL) )
-        break; // found the functions!
-      FreeLibrary(hToolhelp);
-      hToolhelp = NULL;
-    }
+		for (i = 0; i < (sizeof(dllname) / sizeof(dllname[0])); i++)
+		{
+			hToolhelp = LoadLibrary(dllname[i]);
+			if (hToolhelp == NULL)
+				continue;
+			pCT32S = (tCT32S)GetProcAddress(hToolhelp, "CreateToolhelp32Snapshot");
+			pM32F = (tM32F)GetProcAddress(hToolhelp, "Module32First");
+			pM32N = (tM32N)GetProcAddress(hToolhelp, "Module32Next");
+			if ((pCT32S != NULL) && (pM32F != NULL) && (pM32N != NULL))
+				break; // found the functions!
+			FreeLibrary(hToolhelp);
+			hToolhelp = NULL;
+		}
 
-    if (hToolhelp == NULL)
-      return FALSE;
+		if (hToolhelp == NULL)
+			return FALSE;
 
-    hSnap = pCT32S( TH32CS_SNAPMODULE, pid );
-    if (hSnap == (HANDLE) -1)
-      return FALSE;
+		hSnap = pCT32S(TH32CS_SNAPMODULE, pid);
+		if (hSnap == (HANDLE)-1)
+		{
+			FreeLibrary(hToolhelp);
+			return FALSE;
+		}
 
-    keepGoing = !!pM32F( hSnap, &me );
-    int cnt = 0;
-    while (keepGoing)
-    {
-      this->LoadModule(hProcess, me.szExePath, me.szModule, (DWORD64) me.modBaseAddr, me.modBaseSize);
-      cnt++;
-      keepGoing = !!pM32N( hSnap, &me );
-    }
-    CloseHandle(hSnap);
-    FreeLibrary(hToolhelp);
-    if (cnt <= 0)
-      return FALSE;
-    return TRUE;
-  }  // GetModuleListTH32
+		keepGoing = !!pM32F(hSnap, &me);
+		int cnt = 0;
+		while (keepGoing)
+		{
+			this->LoadModule(hProcess, me.szExePath, me.szModule, (DWORD64)me.modBaseAddr,
+				me.modBaseSize);
+			cnt++;
+			keepGoing = !!pM32N(hSnap, &me);
+		}
+		CloseHandle(hSnap);
+		FreeLibrary(hToolhelp);
+		if (cnt <= 0)
+			return FALSE;
+		return TRUE;
+	} // GetModuleListTH32
 
-  // **************************************** PSAPI ************************
-  typedef struct _MODULEINFO {
-      LPVOID lpBaseOfDll;
-      DWORD SizeOfImage;
-      LPVOID EntryPoint;
-  } MODULEINFO, *LPMODULEINFO;
+	  // **************************************** PSAPI ************************
+	typedef struct _MODULEINFO
+	{
+		LPVOID lpBaseOfDll;
+		DWORD  SizeOfImage;
+		LPVOID EntryPoint;
+	} MODULEINFO, *LPMODULEINFO;
 
-  BOOL GetModuleListPSAPI(HANDLE hProcess)
-  {
-    // EnumProcessModules()
-    typedef BOOL (__stdcall *tEPM)(HANDLE hProcess, HMODULE *lphModule, DWORD cb, LPDWORD lpcbNeeded );
-    // GetModuleFileNameEx()
-    typedef DWORD (__stdcall *tGMFNE)(HANDLE hProcess, HMODULE hModule, LPSTR lpFilename, DWORD nSize );
-    // GetModuleBaseName()
-    typedef DWORD (__stdcall *tGMBN)(HANDLE hProcess, HMODULE hModule, LPSTR lpFilename, DWORD nSize );
-    // GetModuleInformation()
-    typedef BOOL (__stdcall *tGMI)(HANDLE hProcess, HMODULE hModule, LPMODULEINFO pmi, DWORD nSize );
+	BOOL GetModuleListPSAPI(HANDLE hProcess)
+	{
+		// EnumProcessModules()
+		typedef BOOL(__stdcall * tEPM)(HANDLE hProcess, HMODULE * lphModule, DWORD cb,
+			LPDWORD lpcbNeeded);
+		// GetModuleFileNameEx()
+		typedef DWORD(__stdcall * tGMFNE)(HANDLE hProcess, HMODULE hModule, LPSTR lpFilename,
+			DWORD nSize);
+		// GetModuleBaseName()
+		typedef DWORD(__stdcall * tGMBN)(HANDLE hProcess, HMODULE hModule, LPSTR lpFilename,
+			DWORD nSize);
+		// GetModuleInformation()
+		typedef BOOL(__stdcall * tGMI)(HANDLE hProcess, HMODULE hModule, LPMODULEINFO pmi, DWORD nSize);
 
-    HINSTANCE hPsapi;
-    tEPM pEPM;
-    tGMFNE pGMFNE;
-    tGMBN pGMBN;
-    tGMI pGMI;
+		HINSTANCE hPsapi;
+		tEPM      pEPM;
+		tGMFNE    pGMFNE;
+		tGMBN     pGMBN;
+		tGMI      pGMI;
 
-    DWORD i;
-    //ModuleEntry e;
-    DWORD cbNeeded;
-    MODULEINFO mi;
-    HMODULE *hMods = 0;
-    char *tt = NULL;
-    char *tt2 = NULL;
-    const SIZE_T TTBUFLEN = 8096;
-    int cnt = 0;
+		DWORD i;
+		//ModuleEntry e;
+		DWORD        cbNeeded;
+		MODULEINFO   mi;
+		HMODULE*     hMods = 0;
+		char*        tt = NULL;
+		char*        tt2 = NULL;
+		const SIZE_T TTBUFLEN = 8096;
+		int          cnt = 0;
 
-    hPsapi = LoadLibrary( _T("psapi.dll") );
-    if (hPsapi == NULL)
-      return FALSE;
+		hPsapi = LoadLibrary(_T("psapi.dll"));
+		if (hPsapi == NULL)
+			return FALSE;
 
-    pEPM = (tEPM) GetProcAddress( hPsapi, "EnumProcessModules" );
-    pGMFNE = (tGMFNE) GetProcAddress( hPsapi, "GetModuleFileNameExA" );
-    pGMBN = (tGMFNE) GetProcAddress( hPsapi, "GetModuleBaseNameA" );
-    pGMI = (tGMI) GetProcAddress( hPsapi, "GetModuleInformation" );
-    if ( (pEPM == NULL) || (pGMFNE == NULL) || (pGMBN == NULL) || (pGMI == NULL) )
-    {
-      // we couldn´t find all functions
-      FreeLibrary(hPsapi);
-      return FALSE;
-    }
+		pEPM = (tEPM)GetProcAddress(hPsapi, "EnumProcessModules");
+		pGMFNE = (tGMFNE)GetProcAddress(hPsapi, "GetModuleFileNameExA");
+		pGMBN = (tGMFNE)GetProcAddress(hPsapi, "GetModuleBaseNameA");
+		pGMI = (tGMI)GetProcAddress(hPsapi, "GetModuleInformation");
+		if ((pEPM == NULL) || (pGMFNE == NULL) || (pGMBN == NULL) || (pGMI == NULL))
+		{
+			// we couldn't find all functions
+			FreeLibrary(hPsapi);
+			return FALSE;
+		}
 
-    hMods = (HMODULE*) malloc(sizeof(HMODULE) * (TTBUFLEN / sizeof HMODULE));
-    tt = (char*) malloc(sizeof(char) * TTBUFLEN);
-    tt2 = (char*) malloc(sizeof(char) * TTBUFLEN);
-    if ( (hMods == NULL) || (tt == NULL) || (tt2 == NULL) )
-      goto cleanup;
+		hMods = (HMODULE*)malloc(sizeof(HMODULE) * (TTBUFLEN / sizeof(HMODULE)));
+		tt = (char*)malloc(sizeof(char) * TTBUFLEN);
+		tt2 = (char*)malloc(sizeof(char) * TTBUFLEN);
+		if ((hMods == NULL) || (tt == NULL) || (tt2 == NULL))
+			goto cleanup;
 
-    if ( ! pEPM( hProcess, hMods, TTBUFLEN, &cbNeeded ) )
-    {
-      //_ftprintf(fLogFile, _T("%lu: EPM failed, GetLastError = %lu\n"), g_dwShowCount, gle );
-      goto cleanup;
-    }
+		if (!pEPM(hProcess, hMods, TTBUFLEN, &cbNeeded))
+		{
+			//_ftprintf(fLogFile, _T("%lu: EPM failed, GetLastError = %lu\n"), g_dwShowCount, gle );
+			goto cleanup;
+		}
 
-    if ( cbNeeded > TTBUFLEN )
-    {
-      //_ftprintf(fLogFile, _T("%lu: More than %lu module handles. Huh?\n"), g_dwShowCount, lenof( hMods ) );
-      goto cleanup;
-    }
+		if (cbNeeded > TTBUFLEN)
+		{
+			//_ftprintf(fLogFile, _T("%lu: More than %lu module handles. Huh?\n"), g_dwShowCount, lenof( hMods ) );
+			goto cleanup;
+		}
 
-    for ( i = 0; i < cbNeeded / sizeof hMods[0]; i++ )
-    {
-      // base address, size
-      pGMI(hProcess, hMods[i], &mi, sizeof mi );
-      // image file name
-      tt[0] = 0;
-      pGMFNE(hProcess, hMods[i], tt, TTBUFLEN );
-      // module name
-      tt2[0] = 0;
-      pGMBN(hProcess, hMods[i], tt2, TTBUFLEN );
+		for (i = 0; i < cbNeeded / sizeof(hMods[0]); i++)
+		{
+			// base address, size
+			pGMI(hProcess, hMods[i], &mi, sizeof(mi));
+			// image file name
+			tt[0] = 0;
+			pGMFNE(hProcess, hMods[i], tt, TTBUFLEN);
+			// module name
+			tt2[0] = 0;
+			pGMBN(hProcess, hMods[i], tt2, TTBUFLEN);
 
-      DWORD dwRes = this->LoadModule(hProcess, tt, tt2, (DWORD64) mi.lpBaseOfDll, mi.SizeOfImage);
-      if (dwRes != ERROR_SUCCESS)
-        this->m_parent->OnDbgHelpErr("LoadModule", dwRes, 0);
-      cnt++;
-    }
+			DWORD dwRes = this->LoadModule(hProcess, tt, tt2, (DWORD64)mi.lpBaseOfDll, mi.SizeOfImage);
+			if (dwRes != ERROR_SUCCESS)
+				this->m_parent->OnDbgHelpErr("LoadModule", dwRes, 0);
+			cnt++;
+		}
 
-  cleanup:
-    if (hPsapi != NULL) FreeLibrary(hPsapi);
-    if (tt2 != NULL) free(tt2);
-    if (tt != NULL) free(tt);
-    if (hMods != NULL) free(hMods);
+	cleanup:
+		if (hPsapi != NULL)
+			FreeLibrary(hPsapi);
+		if (tt2 != NULL)
+			free(tt2);
+		if (tt != NULL)
+			free(tt);
+		if (hMods != NULL)
+			free(hMods);
 
-    return cnt != 0;
-  }  // GetModuleListPSAPI
+		return cnt != 0;
+	} // GetModuleListPSAPI
 
-  DWORD LoadModule(HANDLE hProcess, LPCSTR img, LPCSTR mod, DWORD64 baseAddr, DWORD size)
-  {
-    CHAR *szImg = _strdup(img);
-    CHAR *szMod = _strdup(mod);
-    DWORD result = ERROR_SUCCESS;
-    if ( (szImg == NULL) || (szMod == NULL) )
-      result = ERROR_NOT_ENOUGH_MEMORY;
-    else
-    {
-      if (pSLM(hProcess, 0, szImg, szMod, baseAddr, size) == 0)
-        result = GetLastError();
-    }
-    ULONGLONG fileVersion = 0;
-    if ( (m_parent != NULL) && (szImg != NULL) )
-    {
-      // try to retrive the file-version:
-      if ( (this->m_parent->m_options & StackWalker::RetrieveFileVersion) != 0)
-      {
-        VS_FIXEDFILEINFO *fInfo = NULL;
-        DWORD dwHandle;
-        DWORD dwSize = GetFileVersionInfoSizeA(szImg, &dwHandle);
-        if (dwSize > 0)
-        {
-          LPVOID vData = malloc(dwSize);
-          if (vData != NULL)
-          {
-            if (GetFileVersionInfoA(szImg, dwHandle, dwSize, vData) != 0)
-            {
-              UINT len;
-              TCHAR szSubBlock[] = _T("\\");
-              if (VerQueryValue(vData, szSubBlock, (LPVOID*) &fInfo, &len) == 0)
-                fInfo = NULL;
-              else
-              {
-                fileVersion = ((ULONGLONG)fInfo->dwFileVersionLS) + ((ULONGLONG)fInfo->dwFileVersionMS << 32);
-              }
-            }
-            free(vData);
-          }
-        }
-      }
+	DWORD LoadModule(HANDLE hProcess, LPCSTR img, LPCSTR mod, DWORD64 baseAddr, DWORD size)
+	{
+		CHAR* szImg = _strdup(img);
+		CHAR* szMod = _strdup(mod);
+		DWORD result = ERROR_SUCCESS;
+		if ((szImg == NULL) || (szMod == NULL))
+			result = ERROR_NOT_ENOUGH_MEMORY;
+		else
+		{
+			if (pSLM(hProcess, 0, szImg, szMod, baseAddr, size) == 0)
+				result = GetLastError();
+		}
+		ULONGLONG fileVersion = 0;
+		if ((m_parent != NULL) && (szImg != NULL))
+		{
+			// try to retrieve the file-version:
+			if ((this->m_parent->m_options & StackWalker::RetrieveFileVersion) != 0)
+			{
+				VS_FIXEDFILEINFO* fInfo = NULL;
+				DWORD             dwHandle;
+				DWORD             dwSize = GetFileVersionInfoSizeA(szImg, &dwHandle);
+				if (dwSize > 0)
+				{
+					LPVOID vData = malloc(dwSize);
+					if (vData != NULL)
+					{
+						if (GetFileVersionInfoA(szImg, dwHandle, dwSize, vData) != 0)
+						{
+							UINT  len;
+							TCHAR szSubBlock[] = _T("\\");
+							if (VerQueryValue(vData, szSubBlock, (LPVOID*)&fInfo, &len) == 0)
+								fInfo = NULL;
+							else
+							{
+								fileVersion =
+									((ULONGLONG)fInfo->dwFileVersionLS) + ((ULONGLONG)fInfo->dwFileVersionMS << 32);
+							}
+						}
+						free(vData);
+					}
+				}
+			}
 
-      // Retrive some additional-infos about the module
-      IMAGEHLP_MODULE64_V2 Module;
-      const char *szSymType = "-unknown-";
-      if (this->GetModuleInfo(hProcess, baseAddr, &Module) != FALSE)
-      {
-        switch(Module.SymType)
-        {
-          case SymNone:
-            szSymType = "-nosymbols-";
-            break;
-          case SymCoff:
-            szSymType = "COFF";
-            break;
-          case SymCv:
-            szSymType = "CV";
-            break;
-          case SymPdb:
-            szSymType = "PDB";
-            break;
-          case SymExport:
-            szSymType = "-exported-";
-            break;
-          case SymDeferred:
-            szSymType = "-deferred-";
-            break;
-          case SymSym:
-            szSymType = "SYM";
-            break;
-          case 8: //SymVirtual:
-            szSymType = "Virtual";
-            break;
-          case 9: // SymDia:
-            szSymType = "DIA";
-            break;
-        }
-      }
-      this->m_parent->OnLoadModule(img, mod, baseAddr, size, result, szSymType, Module.LoadedImageName, fileVersion);
-    }
-    if (szImg != NULL) free(szImg);
-    if (szMod != NULL) free(szMod);
-    return result;
-  }
+			// Retrieve some additional-infos about the module
+			IMAGEHLP_MODULE64_V3 Module;
+			const char*          szSymType = "-unknown-";
+			if (this->GetModuleInfo(hProcess, baseAddr, &Module) != FALSE)
+			{
+				switch (Module.SymType)
+				{
+				case SymNone:
+					szSymType = "-nosymbols-";
+					break;
+				case SymCoff: // 1
+					szSymType = "COFF";
+					break;
+				case SymCv: // 2
+					szSymType = "CV";
+					break;
+				case SymPdb: // 3
+					szSymType = "PDB";
+					break;
+				case SymExport: // 4
+					szSymType = "-exported-";
+					break;
+				case SymDeferred: // 5
+					szSymType = "-deferred-";
+					break;
+				case SymSym: // 6
+					szSymType = "SYM";
+					break;
+				case 7: // SymDia:
+					szSymType = "DIA";
+					break;
+				case 8: //SymVirtual:
+					szSymType = "Virtual";
+					break;
+				}
+			}
+			LPCSTR pdbName = Module.LoadedImageName;
+			if (Module.LoadedPdbName[0] != 0)
+				pdbName = Module.LoadedPdbName;
+			this->m_parent->OnLoadModule(img, mod, baseAddr, size, result, szSymType, pdbName,
+				fileVersion);
+		}
+		if (szImg != NULL)
+			free(szImg);
+		if (szMod != NULL)
+			free(szMod);
+		return result;
+	}
+
 public:
-  BOOL LoadModules(HANDLE hProcess, DWORD dwProcessId)
-  {
-    // first try toolhelp32
-    if (GetModuleListTH32(hProcess, dwProcessId))
-      return true;
-    // then try psapi
-    return GetModuleListPSAPI(hProcess);
-  }
+	BOOL LoadModules(HANDLE hProcess, DWORD dwProcessId)
+	{
+		// first try toolhelp32
+		if (GetModuleListTH32(hProcess, dwProcessId))
+			return true;
+		// then try psapi
+		return GetModuleListPSAPI(hProcess);
+	}
 
+	BOOL GetModuleInfo(HANDLE hProcess, DWORD64 baseAddr, IMAGEHLP_MODULE64_V3* pModuleInfo)
+	{
+		memset(pModuleInfo, 0, sizeof(IMAGEHLP_MODULE64_V3));
+		if (this->pSGMI == NULL)
+		{
+			SetLastError(ERROR_DLL_INIT_FAILED);
+			return FALSE;
+		}
+		// First try to use the larger ModuleInfo-Structure
+		pModuleInfo->SizeOfStruct = sizeof(IMAGEHLP_MODULE64_V3);
+		void* pData = malloc(
+			4096); // reserve enough memory, so the bug in v6.3.5.1 does not lead to memory-overwrites...
+		if (pData == NULL)
+		{
+			SetLastError(ERROR_NOT_ENOUGH_MEMORY);
+			return FALSE;
+		}
+		memcpy(pData, pModuleInfo, sizeof(IMAGEHLP_MODULE64_V3));
+		static bool s_useV3Version = true;
+		if (s_useV3Version)
+		{
+			if (this->pSGMI(hProcess, baseAddr, (IMAGEHLP_MODULE64_V3*)pData) != FALSE)
+			{
+				// only copy as much memory as is reserved...
+				memcpy(pModuleInfo, pData, sizeof(IMAGEHLP_MODULE64_V3));
+				pModuleInfo->SizeOfStruct = sizeof(IMAGEHLP_MODULE64_V3);
+				free(pData);
+				return TRUE;
+			}
+			s_useV3Version = false; // to prevent unnecessary calls with the larger struct...
+		}
 
-  BOOL GetModuleInfo(HANDLE hProcess, DWORD64 baseAddr, IMAGEHLP_MODULE64_V2 *pModuleInfo)
-  {
-    if(this->pSGMI == NULL)
-    {
-      SetLastError(ERROR_DLL_INIT_FAILED);
-      return FALSE;
-    }
-    // First try to use the larger ModuleInfo-Structure
-//    memset(pModuleInfo, 0, sizeof(IMAGEHLP_MODULE64_V3));
-//    pModuleInfo->SizeOfStruct = sizeof(IMAGEHLP_MODULE64_V3);
-//    if (this->pSGMI_V3 != NULL)
-//    {
-//      if (this->pSGMI_V3(hProcess, baseAddr, pModuleInfo) != FALSE)
-//        return TRUE;
-//      // check if the parameter was wrong (size is bad...)
-//      if (GetLastError() != ERROR_INVALID_PARAMETER)
-//        return FALSE;
-//    }
-    // could not retrive the bigger structure, try with the smaller one (as defined in VC7.1)...
-    pModuleInfo->SizeOfStruct = sizeof(IMAGEHLP_MODULE64_V2);
-    void *pData = malloc(4096); // reserve enough memory, so the bug in v6.3.5.1 does not lead to memory-overwrites...
-    if (pData == NULL)
-    {
-      SetLastError(ERROR_NOT_ENOUGH_MEMORY);
-      return FALSE;
-    }
-    memcpy(pData, pModuleInfo, sizeof(IMAGEHLP_MODULE64_V2));
-    if (this->pSGMI(hProcess, baseAddr, (IMAGEHLP_MODULE64_V2*) pData) != FALSE)
-    {
-      // only copy as much memory as is reserved...
-      memcpy(pModuleInfo, pData, sizeof(IMAGEHLP_MODULE64_V2));
-      pModuleInfo->SizeOfStruct = sizeof(IMAGEHLP_MODULE64_V2);
-      free(pData);
-      return TRUE;
-    }
-    free(pData);
-    SetLastError(ERROR_DLL_INIT_FAILED);
-    return FALSE;
-  }
+		// could not retrieve the bigger structure, try with the smaller one (as defined in VC7.1)...
+		pModuleInfo->SizeOfStruct = sizeof(IMAGEHLP_MODULE64_V2);
+		memcpy(pData, pModuleInfo, sizeof(IMAGEHLP_MODULE64_V2));
+		if (this->pSGMI(hProcess, baseAddr, (IMAGEHLP_MODULE64_V3*)pData) != FALSE)
+		{
+			// only copy as much memory as is reserved...
+			memcpy(pModuleInfo, pData, sizeof(IMAGEHLP_MODULE64_V2));
+			pModuleInfo->SizeOfStruct = sizeof(IMAGEHLP_MODULE64_V2);
+			free(pData);
+			return TRUE;
+		}
+		free(pData);
+		SetLastError(ERROR_DLL_INIT_FAILED);
+		return FALSE;
+	}
 };
 
 // #############################################################
 StackWalker::StackWalker(DWORD dwProcessId, HANDLE hProcess)
 {
-  this->m_options = OptionsAll;
-  this->m_modulesLoaded = FALSE;
-  this->m_hProcess = hProcess;
-  this->m_sw = new StackWalkerInternal(this, this->m_hProcess);
-  this->m_dwProcessId = dwProcessId;
-  this->m_szSymPath = NULL;
+	this->m_options = OptionsAll;
+	this->m_modulesLoaded = FALSE;
+	this->m_hProcess = hProcess;
+	this->m_sw = new StackWalkerInternal(this, this->m_hProcess);
+	this->m_dwProcessId = dwProcessId;
+	this->m_szSymPath = NULL;
+	this->m_MaxRecursionCount = 1000;
 }
 StackWalker::StackWalker(int options, LPCSTR szSymPath, DWORD dwProcessId, HANDLE hProcess)
 {
-  this->m_options = options;
-  this->m_modulesLoaded = FALSE;
-  this->m_hProcess = hProcess;
-  this->m_sw = new StackWalkerInternal(this, this->m_hProcess);
-  this->m_dwProcessId = dwProcessId;
-  if (szSymPath != NULL)
-  {
-    this->m_szSymPath = _strdup(szSymPath);
-    this->m_options |= SymBuildPath;
-  }
-  else
-    this->m_szSymPath = NULL;
+	this->m_options = options;
+	this->m_modulesLoaded = FALSE;
+	this->m_hProcess = hProcess;
+	this->m_sw = new StackWalkerInternal(this, this->m_hProcess);
+	this->m_dwProcessId = dwProcessId;
+	if (szSymPath != NULL)
+	{
+		this->m_szSymPath = _strdup(szSymPath);
+		this->m_options |= SymBuildPath;
+	}
+	else
+		this->m_szSymPath = NULL;
+	this->m_MaxRecursionCount = 1000;
 }
 
 StackWalker::~StackWalker()
 {
-  if (m_szSymPath != NULL)
-    free(m_szSymPath);
-  m_szSymPath = NULL;
-  if (this->m_sw != NULL)
-    delete this->m_sw;
-  this->m_sw = NULL;
+	if (m_szSymPath != NULL)
+		free(m_szSymPath);
+	m_szSymPath = NULL;
+	if (this->m_sw != NULL)
+		delete this->m_sw;
+	this->m_sw = NULL;
 }
 
 BOOL StackWalker::LoadModules()
 {
-  if (this->m_sw == NULL)
-  {
-    SetLastError(ERROR_DLL_INIT_FAILED);
-    return FALSE;
-  }
-  if (m_modulesLoaded != FALSE)
-    return TRUE;
+	if (this->m_sw == NULL)
+	{
+		SetLastError(ERROR_DLL_INIT_FAILED);
+		return FALSE;
+	}
+	if (m_modulesLoaded != FALSE)
+		return TRUE;
 
-  // Build the sym-path:
-  char *szSymPath = NULL;
-  if ( (this->m_options & SymBuildPath) != 0)
-  {
-    const size_t nSymPathLen = 4096;
-    szSymPath = (char*) malloc(nSymPathLen);
-    if (szSymPath == NULL)
-    {
-      SetLastError(ERROR_NOT_ENOUGH_MEMORY);
-      return FALSE;
-    }
-    szSymPath[0] = 0;
-    // Now first add the (optional) provided sympath:
-    if (this->m_szSymPath != NULL)
-    {
-      strcat_s(szSymPath, nSymPathLen, this->m_szSymPath);
-      strcat_s(szSymPath, nSymPathLen, ";");
-    }
+	// Build the sym-path:
+	char* szSymPath = NULL;
+	if ((this->m_options & SymBuildPath) != 0)
+	{
+		const size_t nSymPathLen = 4096;
+		szSymPath = (char*)malloc(nSymPathLen);
+		if (szSymPath == NULL)
+		{
+			SetLastError(ERROR_NOT_ENOUGH_MEMORY);
+			return FALSE;
+		}
+		szSymPath[0] = 0;
+		// Now first add the (optional) provided sympath:
+		if (this->m_szSymPath != NULL)
+		{
+			strcat_s(szSymPath, nSymPathLen, this->m_szSymPath);
+			strcat_s(szSymPath, nSymPathLen, ";");
+		}
 
-    strcat_s(szSymPath, nSymPathLen, ".;");
+		strcat_s(szSymPath, nSymPathLen, ".;");
 
-    const size_t nTempLen = 1024;
-    char szTemp[nTempLen];
-    // Now add the current directory:
-    if (GetCurrentDirectoryA(nTempLen, szTemp) > 0)
-    {
-      szTemp[nTempLen-1] = 0;
-      strcat_s(szSymPath, nSymPathLen, szTemp);
-      strcat_s(szSymPath, nSymPathLen, ";");
-    }
+		const size_t nTempLen = 1024;
+		char         szTemp[nTempLen];
+		// Now add the current directory:
+		if (GetCurrentDirectoryA(nTempLen, szTemp) > 0)
+		{
+			szTemp[nTempLen - 1] = 0;
+			strcat_s(szSymPath, nSymPathLen, szTemp);
+			strcat_s(szSymPath, nSymPathLen, ";");
+		}
 
-    // Now add the path for the main-module:
-    if (GetModuleFileNameA(NULL, szTemp, nTempLen) > 0)
-    {
-      szTemp[nTempLen-1] = 0;
-      for (char *p = (szTemp+strlen(szTemp)-1); p >= szTemp; --p)
-      {
-        // locate the rightmost path separator
-        if ( (*p == '\\') || (*p == '/') || (*p == ':') )
-        {
-          *p = 0;
-          break;
-        }
-      }  // for (search for path separator...)
-      if (strlen(szTemp) > 0)
-      {
-        strcat_s(szSymPath, nSymPathLen, szTemp);
-        strcat_s(szSymPath, nSymPathLen, ";");
-      }
-    }
-    if (GetEnvironmentVariableA("_NT_SYMBOL_PATH", szTemp, nTempLen) > 0)
-    {
-      szTemp[nTempLen-1] = 0;
-      strcat_s(szSymPath, nSymPathLen, szTemp);
-      strcat_s(szSymPath, nSymPathLen, ";");
-    }
-    if (GetEnvironmentVariableA("_NT_ALTERNATE_SYMBOL_PATH", szTemp, nTempLen) > 0)
-    {
-      szTemp[nTempLen-1] = 0;
-      strcat_s(szSymPath, nSymPathLen, szTemp);
-      strcat_s(szSymPath, nSymPathLen, ";");
-    }
-    if (GetEnvironmentVariableA("SYSTEMROOT", szTemp, nTempLen) > 0)
-    {
-      szTemp[nTempLen-1] = 0;
-      strcat_s(szSymPath, nSymPathLen, szTemp);
-      strcat_s(szSymPath, nSymPathLen, ";");
-      // also add the "system32"-directory:
-      strcat_s(szTemp, nTempLen, "\\system32");
-      strcat_s(szSymPath, nSymPathLen, szTemp);
-      strcat_s(szSymPath, nSymPathLen, ";");
-    }
+		// Now add the path for the main-module:
+		if (GetModuleFileNameA(NULL, szTemp, nTempLen) > 0)
+		{
+			szTemp[nTempLen - 1] = 0;
+			for (char* p = (szTemp + strlen(szTemp) - 1); p >= szTemp; --p)
+			{
+				// locate the rightmost path separator
+				if ((*p == '\\') || (*p == '/') || (*p == ':'))
+				{
+					*p = 0;
+					break;
+				}
+			} // for (search for path separator...)
+			if (strlen(szTemp) > 0)
+			{
+				strcat_s(szSymPath, nSymPathLen, szTemp);
+				strcat_s(szSymPath, nSymPathLen, ";");
+			}
+		}
+		if (GetEnvironmentVariableA("_NT_SYMBOL_PATH", szTemp, nTempLen) > 0)
+		{
+			szTemp[nTempLen - 1] = 0;
+			strcat_s(szSymPath, nSymPathLen, szTemp);
+			strcat_s(szSymPath, nSymPathLen, ";");
+		}
+		if (GetEnvironmentVariableA("_NT_ALTERNATE_SYMBOL_PATH", szTemp, nTempLen) > 0)
+		{
+			szTemp[nTempLen - 1] = 0;
+			strcat_s(szSymPath, nSymPathLen, szTemp);
+			strcat_s(szSymPath, nSymPathLen, ";");
+		}
+		if (GetEnvironmentVariableA("SYSTEMROOT", szTemp, nTempLen) > 0)
+		{
+			szTemp[nTempLen - 1] = 0;
+			strcat_s(szSymPath, nSymPathLen, szTemp);
+			strcat_s(szSymPath, nSymPathLen, ";");
+			// also add the "system32"-directory:
+			strcat_s(szTemp, nTempLen, "\\system32");
+			strcat_s(szSymPath, nSymPathLen, szTemp);
+			strcat_s(szSymPath, nSymPathLen, ";");
+		}
 
-    if ( (this->m_options & SymBuildPath) != 0)
-    {
-      if (GetEnvironmentVariableA("SYSTEMDRIVE", szTemp, nTempLen) > 0)
-      {
-        szTemp[nTempLen-1] = 0;
-        strcat_s(szSymPath, nSymPathLen, "SRV*");
-        strcat_s(szSymPath, nSymPathLen, szTemp);
-        strcat_s(szSymPath, nSymPathLen, "\\websymbols");
-        strcat_s(szSymPath, nSymPathLen, "*http://msdl.microsoft.com/download/symbols;");
-      }
-      else
-        strcat_s(szSymPath, nSymPathLen, "SRV*c:\\websymbols*http://msdl.microsoft.com/download/symbols;");
-    }
-  }
+		if ((this->m_options & SymUseSymSrv) != 0)
+		{
+			if (GetEnvironmentVariableA("SYSTEMDRIVE", szTemp, nTempLen) > 0)
+			{
+				szTemp[nTempLen - 1] = 0;
+				strcat_s(szSymPath, nSymPathLen, "SRV*");
+				strcat_s(szSymPath, nSymPathLen, szTemp);
+				strcat_s(szSymPath, nSymPathLen, "\\websymbols");
+				strcat_s(szSymPath, nSymPathLen, "*http://msdl.microsoft.com/download/symbols;");
+			}
+			else
+				strcat_s(szSymPath, nSymPathLen,
+					"SRV*c:\\websymbols*http://msdl.microsoft.com/download/symbols;");
+		}
+	} // if SymBuildPath
 
-  // First Init the whole stuff...
-  BOOL bRet = this->m_sw->Init(szSymPath);
-  if (szSymPath != NULL) free(szSymPath); szSymPath = NULL;
-  if (bRet == FALSE)
-  {
-    this->OnDbgHelpErr("Error while initializing dbghelp.dll", 0, 0);
-    SetLastError(ERROR_DLL_INIT_FAILED);
-    return FALSE;
-  }
+	  // First Init the whole stuff...
+	BOOL bRet = this->m_sw->Init(szSymPath);
+	if (szSymPath != NULL)
+		free(szSymPath);
+	szSymPath = NULL;
+	if (bRet == FALSE)
+	{
+		this->OnDbgHelpErr("Error while initializing dbghelp.dll", 0, 0);
+		SetLastError(ERROR_DLL_INIT_FAILED);
+		return FALSE;
+	}
 
-  bRet = this->m_sw->LoadModules(this->m_hProcess, this->m_dwProcessId);
-  if (bRet != FALSE)
-    m_modulesLoaded = TRUE;
-  return bRet;
+	bRet = this->m_sw->LoadModules(this->m_hProcess, this->m_dwProcessId);
+	if (bRet != FALSE)
+		m_modulesLoaded = TRUE;
+	return bRet;
 }
-
 
 // The following is used to pass the "userData"-Pointer to the user-provided readMemoryFunction
 // This has to be done due to a problem with the "hProcess"-parameter in x64...
-// Because this class is in no case multi-threading-enabled (because of the limitations 
+// Because this class is in no case multi-threading-enabled (because of the limitations
 // of dbghelp.dll) it is "safe" to use a static-variable
 static StackWalker::PReadProcessMemoryRoutine s_readMemoryFunction = NULL;
-static LPVOID s_readMemoryFunction_UserData = NULL;
+static LPVOID                                 s_readMemoryFunction_UserData = NULL;
 
-BOOL StackWalker::ShowCallstack(HANDLE hThread, const CONTEXT *context, PReadProcessMemoryRoutine readMemoryFunction, LPVOID pUserData)
+BOOL StackWalker::ShowCallstack(HANDLE                    hThread,
+	const CONTEXT*            context,
+	PReadProcessMemoryRoutine readMemoryFunction,
+	LPVOID                    pUserData)
 {
-  CONTEXT c;;
-  CallstackEntry csEntry;
-  IMAGEHLP_SYMBOL64 *pSym = NULL;
-  StackWalkerInternal::IMAGEHLP_MODULE64_V2 Module;
-  IMAGEHLP_LINE64 Line;
-  int frameNum;
+	CONTEXT                                   c;
+	CallstackEntry                            csEntry;
+	IMAGEHLP_SYMBOL64*                        pSym = NULL;
+	StackWalkerInternal::IMAGEHLP_MODULE64_V3 Module;
+	IMAGEHLP_LINE64                           Line;
+	int                                       frameNum;
+	bool                                      bLastEntryCalled = true;
+	int                                       curRecursionCount = 0;
 
-  if (m_modulesLoaded == FALSE)
-    this->LoadModules();  // ignore the result...
+	if (m_modulesLoaded == FALSE)
+		this->LoadModules(); // ignore the result...
 
-  if (this->m_sw->m_hDbhHelp == NULL)
-  {
-    SetLastError(ERROR_DLL_INIT_FAILED);
-    return FALSE;
-  }
+	if (this->m_sw->m_hDbhHelp == NULL)
+	{
+		SetLastError(ERROR_DLL_INIT_FAILED);
+		return FALSE;
+	}
 
-  s_readMemoryFunction = readMemoryFunction;
-  s_readMemoryFunction_UserData = pUserData;
+	s_readMemoryFunction = readMemoryFunction;
+	s_readMemoryFunction_UserData = pUserData;
 
-  if (context == NULL)
-  {
-    // If no context is provided, capture the context
-    if (hThread == GetCurrentThread())
-    {
-      GET_CURRENT_CONTEXT(c, USED_CONTEXT_FLAGS);
-    }
-    else
-    {
-      SuspendThread(hThread);
-      memset(&c, 0, sizeof(CONTEXT));
-      c.ContextFlags = USED_CONTEXT_FLAGS;
-      if (GetThreadContext(hThread, &c) == FALSE)
-      {
-        ResumeThread(hThread);
-        return FALSE;
-      }
-    }
-  }
-  else
-    c = *context;
+	if (context == NULL)
+	{
+		// If no context is provided, capture the context
+		// See: https://stackwalker.codeplex.com/discussions/446958
+#if _WIN32_WINNT <= 0x0501
+		// If we need to support XP, we need to use the "old way", because "GetThreadId" is not available!
+		if (hThread == GetCurrentThread())
+#else
+		if (GetThreadId(hThread) == GetCurrentThreadId())
+#endif
+		{
+			GET_CURRENT_CONTEXT_STACKWALKER_CODEPLEX(c, USED_CONTEXT_FLAGS);
+		}
+		else
+		{
+			SuspendThread(hThread);
+			memset(&c, 0, sizeof(CONTEXT));
+			c.ContextFlags = USED_CONTEXT_FLAGS;
 
-  // init STACKFRAME for first call
-  STACKFRAME64 s; // in/out stackframe
-  memset(&s, 0, sizeof(s));
-  DWORD imageType;
+			// TODO: Detect if you want to get a thread context of a different process, which is running a different processor architecture...
+			// This does only work if we are x64 and the target process is x64 or x86;
+			// It cannot work, if this process is x64 and the target process is x64... this is not supported...
+			// See also: http://www.howzatt.demon.co.uk/articles/DebuggingInWin64.html
+			if (GetThreadContext(hThread, &c) == FALSE)
+			{
+				ResumeThread(hThread);
+				return FALSE;
+			}
+		}
+	}
+	else
+		c = *context;
+
+	// init STACKFRAME for first call
+	STACKFRAME64 s; // in/out stackframe
+	memset(&s, 0, sizeof(s));
+	DWORD imageType;
 #ifdef _M_IX86
-  // normally, call ImageNtHeader() and use machine info from PE header
-  imageType = IMAGE_FILE_MACHINE_I386;
-  s.AddrPC.Offset = c.Eip;
-  s.AddrPC.Mode = AddrModeFlat;
-  s.AddrFrame.Offset = c.Ebp;
-  s.AddrFrame.Mode = AddrModeFlat;
-  s.AddrStack.Offset = c.Esp;
-  s.AddrStack.Mode = AddrModeFlat;
+	// normally, call ImageNtHeader() and use machine info from PE header
+	imageType = IMAGE_FILE_MACHINE_I386;
+	s.AddrPC.Offset = c.Eip;
+	s.AddrPC.Mode = AddrModeFlat;
+	s.AddrFrame.Offset = c.Ebp;
+	s.AddrFrame.Mode = AddrModeFlat;
+	s.AddrStack.Offset = c.Esp;
+	s.AddrStack.Mode = AddrModeFlat;
 #elif _M_X64
-  imageType = IMAGE_FILE_MACHINE_AMD64;
-  s.AddrPC.Offset = c.Rip;
-  s.AddrPC.Mode = AddrModeFlat;
-  s.AddrFrame.Offset = c.Rsp;
-  s.AddrFrame.Mode = AddrModeFlat;
-  s.AddrStack.Offset = c.Rsp;
-  s.AddrStack.Mode = AddrModeFlat;
+	imageType = IMAGE_FILE_MACHINE_AMD64;
+	s.AddrPC.Offset = c.Rip;
+	s.AddrPC.Mode = AddrModeFlat;
+	s.AddrFrame.Offset = c.Rsp;
+	s.AddrFrame.Mode = AddrModeFlat;
+	s.AddrStack.Offset = c.Rsp;
+	s.AddrStack.Mode = AddrModeFlat;
 #elif _M_IA64
-  imageType = IMAGE_FILE_MACHINE_IA64;
-  s.AddrPC.Offset = c.StIIP;
-  s.AddrPC.Mode = AddrModeFlat;
-  s.AddrFrame.Offset = c.IntSp;
-  s.AddrFrame.Mode = AddrModeFlat;
-  s.AddrBStore.Offset = c.RsBSP;
-  s.AddrBStore.Mode = AddrModeFlat;
-  s.AddrStack.Offset = c.IntSp;
-  s.AddrStack.Mode = AddrModeFlat;
+	imageType = IMAGE_FILE_MACHINE_IA64;
+	s.AddrPC.Offset = c.StIIP;
+	s.AddrPC.Mode = AddrModeFlat;
+	s.AddrFrame.Offset = c.IntSp;
+	s.AddrFrame.Mode = AddrModeFlat;
+	s.AddrBStore.Offset = c.RsBSP;
+	s.AddrBStore.Mode = AddrModeFlat;
+	s.AddrStack.Offset = c.IntSp;
+	s.AddrStack.Mode = AddrModeFlat;
 #else
 #error "Platform not supported!"
 #endif
 
-  pSym = (IMAGEHLP_SYMBOL64 *) malloc(sizeof(IMAGEHLP_SYMBOL64) + STACKWALK_MAX_NAMELEN);
-  if (!pSym) goto cleanup;  // not enough memory...
-  memset(pSym, 0, sizeof(IMAGEHLP_SYMBOL64) + STACKWALK_MAX_NAMELEN);
-  pSym->SizeOfStruct = sizeof(IMAGEHLP_SYMBOL64);
-  pSym->MaxNameLength = STACKWALK_MAX_NAMELEN;
+	pSym = (IMAGEHLP_SYMBOL64*)malloc(sizeof(IMAGEHLP_SYMBOL64) + STACKWALK_MAX_NAMELEN);
+	if (!pSym)
+		goto cleanup; // not enough memory...
+	memset(pSym, 0, sizeof(IMAGEHLP_SYMBOL64) + STACKWALK_MAX_NAMELEN);
+	pSym->SizeOfStruct = sizeof(IMAGEHLP_SYMBOL64);
+	pSym->MaxNameLength = STACKWALK_MAX_NAMELEN;
 
-  memset(&Line, 0, sizeof(Line));
-  Line.SizeOfStruct = sizeof(Line);
+	memset(&Line, 0, sizeof(Line));
+	Line.SizeOfStruct = sizeof(Line);
 
-  memset(&Module, 0, sizeof(Module));
-  Module.SizeOfStruct = sizeof(Module);
+	memset(&Module, 0, sizeof(Module));
+	Module.SizeOfStruct = sizeof(Module);
 
-  for (frameNum = 0; ; ++frameNum )
-  {
-    // get next stack frame (StackWalk64(), SymFunctionTableAccess64(), SymGetModuleBase64())
-    // if this returns ERROR_INVALID_ADDRESS (487) or ERROR_NOACCESS (998), you can
-    // assume that either you are done, or that the stack is so hosed that the next
-    // deeper frame could not be found.
-    // CONTEXT need not to be suplied if imageTyp is IMAGE_FILE_MACHINE_I386!
-    if ( ! this->m_sw->pSW(imageType, this->m_hProcess, hThread, &s, &c, myReadProcMem, this->m_sw->pSFTA, this->m_sw->pSGMB, NULL) )
-    {
-      this->OnDbgHelpErr("StackWalk64", GetLastError(), s.AddrPC.Offset);
-      break;
-    }
+	for (frameNum = 0;; ++frameNum)
+	{
+		// get next stack frame (StackWalk64(), SymFunctionTableAccess64(), SymGetModuleBase64())
+		// if this returns ERROR_INVALID_ADDRESS (487) or ERROR_NOACCESS (998), you can
+		// assume that either you are done, or that the stack is so hosed that the next
+		// deeper frame could not be found.
+		// CONTEXT need not to be supplied if imageTyp is IMAGE_FILE_MACHINE_I386!
+		if (!this->m_sw->pSW(imageType, this->m_hProcess, hThread, &s, &c, myReadProcMem,
+			this->m_sw->pSFTA, this->m_sw->pSGMB, NULL))
+		{
+			// INFO: "StackWalk64" does not set "GetLastError"...
+			this->OnDbgHelpErr("StackWalk64", 0, s.AddrPC.Offset);
+			break;
+		}
 
-    csEntry.offset = s.AddrPC.Offset;
-    csEntry.name[0] = 0;
-    csEntry.undName[0] = 0;
-    csEntry.undFullName[0] = 0;
-    csEntry.offsetFromSmybol = 0;
-    csEntry.offsetFromLine = 0;
-    csEntry.lineFileName[0] = 0;
-    csEntry.lineNumber = 0;
-    csEntry.loadedImageName[0] = 0;
-    csEntry.moduleName[0] = 0;
-    if (s.AddrPC.Offset == s.AddrReturn.Offset)
-    {
-      this->OnDbgHelpErr("StackWalk64-Endless-Callstack!", 0, s.AddrPC.Offset);
-      break;
-    }
-    if (s.AddrPC.Offset != 0)
-    {
-      // we seem to have a valid PC
-      // show procedure info (SymGetSymFromAddr64())
-      if (this->m_sw->pSGSFA(this->m_hProcess, s.AddrPC.Offset, &(csEntry.offsetFromSmybol), pSym) != FALSE)
-      {
-        // TODO: Mache dies sicher...!
-        strcpy_s(csEntry.name, pSym->Name);
-        // UnDecorateSymbolName()
-        this->m_sw->pUDSN( pSym->Name, csEntry.undName, STACKWALK_MAX_NAMELEN, UNDNAME_NAME_ONLY );
-        this->m_sw->pUDSN( pSym->Name, csEntry.undFullName, STACKWALK_MAX_NAMELEN, UNDNAME_COMPLETE );
-      }
-      else
-      {
-        this->OnDbgHelpErr("SymGetSymFromAddr64", GetLastError(), s.AddrPC.Offset);
-      }
+		csEntry.offset = s.AddrPC.Offset;
+		csEntry.name[0] = 0;
+		csEntry.undName[0] = 0;
+		csEntry.undFullName[0] = 0;
+		csEntry.offsetFromSmybol = 0;
+		csEntry.offsetFromLine = 0;
+		csEntry.lineFileName[0] = 0;
+		csEntry.lineNumber = 0;
+		csEntry.loadedImageName[0] = 0;
+		csEntry.moduleName[0] = 0;
+		if (s.AddrPC.Offset == s.AddrReturn.Offset)
+		{
+			if ((this->m_MaxRecursionCount > 0) && (curRecursionCount > m_MaxRecursionCount))
+			{
+				this->OnDbgHelpErr("StackWalk64-Endless-Callstack!", 0, s.AddrPC.Offset);
+				break;
+			}
+			curRecursionCount++;
+		}
+		else
+			curRecursionCount = 0;
+		if (s.AddrPC.Offset != 0)
+		{
+			// we seem to have a valid PC
+			// show procedure info (SymGetSymFromAddr64())
+			if (this->m_sw->pSGSFA(this->m_hProcess, s.AddrPC.Offset, &(csEntry.offsetFromSmybol),
+				pSym) != FALSE)
+			{
+				MyStrCpy(csEntry.name, STACKWALK_MAX_NAMELEN, pSym->Name);
+				// UnDecorateSymbolName()
+				this->m_sw->pUDSN(pSym->Name, csEntry.undName, STACKWALK_MAX_NAMELEN, UNDNAME_NAME_ONLY);
+				this->m_sw->pUDSN(pSym->Name, csEntry.undFullName, STACKWALK_MAX_NAMELEN, UNDNAME_COMPLETE);
+			}
+			else
+			{
+				this->OnDbgHelpErr("SymGetSymFromAddr64", GetLastError(), s.AddrPC.Offset);
+			}
 
-      // show line number info, NT5.0-method (SymGetLineFromAddr64())
-      if (this->m_sw->pSGLFA != NULL )
-      { // yes, we have SymGetLineFromAddr64()
-        if (this->m_sw->pSGLFA(this->m_hProcess, s.AddrPC.Offset, &(csEntry.offsetFromLine), &Line) != FALSE)
-        {
-          csEntry.lineNumber = Line.LineNumber;
-          // TODO: Mache dies sicher...!
-          strcpy_s(csEntry.lineFileName, Line.FileName);
-        }
-        else
-        {
-          this->OnDbgHelpErr("SymGetLineFromAddr64", GetLastError(), s.AddrPC.Offset);
-        }
-      } // yes, we have SymGetLineFromAddr64()
+			// show line number info, NT5.0-method (SymGetLineFromAddr64())
+			if (this->m_sw->pSGLFA != NULL)
+			{ // yes, we have SymGetLineFromAddr64()
+				if (this->m_sw->pSGLFA(this->m_hProcess, s.AddrPC.Offset, &(csEntry.offsetFromLine),
+					&Line) != FALSE)
+				{
+					csEntry.lineNumber = Line.LineNumber;
+					MyStrCpy(csEntry.lineFileName, STACKWALK_MAX_NAMELEN, Line.FileName);
+				}
+				else
+				{
+					this->OnDbgHelpErr("SymGetLineFromAddr64", GetLastError(), s.AddrPC.Offset);
+				}
+			} // yes, we have SymGetLineFromAddr64()
 
-      // show module info (SymGetModuleInfo64())
-      if (this->m_sw->GetModuleInfo(this->m_hProcess, s.AddrPC.Offset, &Module ) != FALSE)
-      { // got module info OK
-        switch ( Module.SymType )
-        {
-        case SymNone:
-          csEntry.symTypeString = "-nosymbols-";
-          break;
-        case SymCoff:
-          csEntry.symTypeString = "COFF";
-          break;
-        case SymCv:
-          csEntry.symTypeString = "CV";
-          break;
-        case SymPdb:
-          csEntry.symTypeString = "PDB";
-          break;
-        case SymExport:
-          csEntry.symTypeString = "-exported-";
-          break;
-        case SymDeferred:
-          csEntry.symTypeString = "-deferred-";
-          break;
-        case SymSym:
-          csEntry.symTypeString = "SYM";
-          break;
+			  // show module info (SymGetModuleInfo64())
+			if (this->m_sw->GetModuleInfo(this->m_hProcess, s.AddrPC.Offset, &Module) != FALSE)
+			{ // got module info OK
+				switch (Module.SymType)
+				{
+				case SymNone:
+					csEntry.symTypeString = "-nosymbols-";
+					break;
+				case SymCoff:
+					csEntry.symTypeString = "COFF";
+					break;
+				case SymCv:
+					csEntry.symTypeString = "CV";
+					break;
+				case SymPdb:
+					csEntry.symTypeString = "PDB";
+					break;
+				case SymExport:
+					csEntry.symTypeString = "-exported-";
+					break;
+				case SymDeferred:
+					csEntry.symTypeString = "-deferred-";
+					break;
+				case SymSym:
+					csEntry.symTypeString = "SYM";
+					break;
 #if API_VERSION_NUMBER >= 9
-        case SymDia:
-          csEntry.symTypeString = "DIA";
-          break;
+				case SymDia:
+					csEntry.symTypeString = "DIA";
+					break;
 #endif
-        case 8: //SymVirtual:
-          csEntry.symTypeString = "Virtual";
-          break;
-        default:
-          //_snprintf( ty, sizeof ty, "symtype=%ld", (long) Module.SymType );
-          csEntry.symTypeString = NULL;
-          break;
-        }
+				case 8: //SymVirtual:
+					csEntry.symTypeString = "Virtual";
+					break;
+				default:
+					//_snprintf( ty, sizeof(ty), "symtype=%ld", (long) Module.SymType );
+					csEntry.symTypeString = NULL;
+					break;
+				}
 
-        // TODO: Mache dies sicher...!
-        strcpy_s(csEntry.moduleName, Module.ModuleName);
-        csEntry.baseOfImage = Module.BaseOfImage;
-        strcpy_s(csEntry.loadedImageName, Module.LoadedImageName);
-      } // got module info OK
-      else
-      {
-        this->OnDbgHelpErr("SymGetModuleInfo64", GetLastError(), s.AddrPC.Offset);
-      }
-    } // we seem to have a valid PC
+				MyStrCpy(csEntry.moduleName, STACKWALK_MAX_NAMELEN, Module.ModuleName);
+				csEntry.baseOfImage = Module.BaseOfImage;
+				MyStrCpy(csEntry.loadedImageName, STACKWALK_MAX_NAMELEN, Module.LoadedImageName);
+			} // got module info OK
+			else
+			{
+				this->OnDbgHelpErr("SymGetModuleInfo64", GetLastError(), s.AddrPC.Offset);
+			}
+		} // we seem to have a valid PC
 
-    CallstackEntryType et = nextEntry;
-    if (frameNum == 0)
-      et = firstEntry;
-    this->OnCallstackEntry(et, csEntry);
-    
-    if (s.AddrReturn.Offset == 0)
-    {
-      this->OnCallstackEntry(lastEntry, csEntry);
-      SetLastError(ERROR_SUCCESS);
-      break;
-    }
-  } // for ( frameNum )
+		CallstackEntryType et = nextEntry;
+		if (frameNum == 0)
+			et = firstEntry;
+		bLastEntryCalled = false;
+		this->OnCallstackEntry(et, csEntry);
 
-  cleanup:
-    if (pSym) free( pSym );
+		if (s.AddrReturn.Offset == 0)
+		{
+			bLastEntryCalled = true;
+			this->OnCallstackEntry(lastEntry, csEntry);
+			SetLastError(ERROR_SUCCESS);
+			break;
+		}
+	} // for ( frameNum )
 
-  if (context == NULL)
-    ResumeThread(hThread);
+cleanup:
+	if (pSym)
+		free(pSym);
 
-  return TRUE;
+	if (bLastEntryCalled == false)
+		this->OnCallstackEntry(lastEntry, csEntry);
+
+	if (context == NULL)
+		ResumeThread(hThread);
+
+	return TRUE;
 }
 
-BOOL __stdcall StackWalker::myReadProcMem(
-    HANDLE      hProcess,
-    DWORD64     qwBaseAddress,
-    PVOID       lpBuffer,
-    DWORD       nSize,
-    LPDWORD     lpNumberOfBytesRead
-    )
+BOOL StackWalker::ShowObject(LPVOID pObject)
 {
-  if (s_readMemoryFunction == NULL)
-  {
-    SIZE_T st;
-    BOOL bRet = ReadProcessMemory(hProcess, (LPVOID) qwBaseAddress, lpBuffer, nSize, &st);
-    *lpNumberOfBytesRead = (DWORD) st;
-    //printf("ReadMemory: hProcess: %p, baseAddr: %p, buffer: %p, size: %d, read: %d, result: %d\n", hProcess, (LPVOID) qwBaseAddress, lpBuffer, nSize, (DWORD) st, (DWORD) bRet);
-    return bRet;
-  }
-  else
-  {
-    return s_readMemoryFunction(hProcess, qwBaseAddress, lpBuffer, nSize, lpNumberOfBytesRead, s_readMemoryFunction_UserData);
-  }
+	// Load modules if not done yet
+	if (m_modulesLoaded == FALSE)
+		this->LoadModules(); // ignore the result...
+
+							 // Verify that the DebugHelp.dll was actually found
+	if (this->m_sw->m_hDbhHelp == NULL)
+	{
+		SetLastError(ERROR_DLL_INIT_FAILED);
+		return FALSE;
+	}
+
+	// SymGetSymFromAddr64() is required
+	if (this->m_sw->pSGSFA == NULL)
+		return FALSE;
+
+	// Show object info (SymGetSymFromAddr64())
+	DWORD64            dwAddress = DWORD64(pObject);
+	DWORD64            dwDisplacement = 0;
+	IMAGEHLP_SYMBOL64* pSym =
+		(IMAGEHLP_SYMBOL64*)malloc(sizeof(IMAGEHLP_SYMBOL64) + STACKWALK_MAX_NAMELEN);
+	memset(pSym, 0, sizeof(IMAGEHLP_SYMBOL64) + STACKWALK_MAX_NAMELEN);
+	pSym->SizeOfStruct = sizeof(IMAGEHLP_SYMBOL64);
+	pSym->MaxNameLength = STACKWALK_MAX_NAMELEN;
+	if (this->m_sw->pSGSFA(this->m_hProcess, dwAddress, &dwDisplacement, pSym) == FALSE)
+	{
+		this->OnDbgHelpErr("SymGetSymFromAddr64", GetLastError(), dwAddress);
+		return FALSE;
+	}
+	// Object name output
+	this->OnOutput(pSym->Name);
+
+	free(pSym);
+	return TRUE;
+};
+
+BOOL __stdcall StackWalker::myReadProcMem(HANDLE  hProcess,
+	DWORD64 qwBaseAddress,
+	PVOID   lpBuffer,
+	DWORD   nSize,
+	LPDWORD lpNumberOfBytesRead)
+{
+	if (s_readMemoryFunction == NULL)
+	{
+		SIZE_T st;
+		BOOL   bRet = ReadProcessMemory(hProcess, (LPVOID)qwBaseAddress, lpBuffer, nSize, &st);
+		*lpNumberOfBytesRead = (DWORD)st;
+		//printf("ReadMemory: hProcess: %p, baseAddr: %p, buffer: %p, size: %d, read: %d, result: %d\n", hProcess, (LPVOID) qwBaseAddress, lpBuffer, nSize, (DWORD) st, (DWORD) bRet);
+		return bRet;
+	}
+	else
+	{
+		return s_readMemoryFunction(hProcess, qwBaseAddress, lpBuffer, nSize, lpNumberOfBytesRead,
+			s_readMemoryFunction_UserData);
+	}
 }
 
-void StackWalker::OnLoadModule(LPCSTR img, LPCSTR mod, DWORD64 baseAddr, DWORD size, DWORD result, LPCSTR symType, LPCSTR pdbName, ULONGLONG fileVersion)
+void StackWalker::OnLoadModule(LPCSTR    img,
+	LPCSTR    mod,
+	DWORD64   baseAddr,
+	DWORD     size,
+	DWORD     result,
+	LPCSTR    symType,
+	LPCSTR    pdbName,
+	ULONGLONG fileVersion)
 {
-  CHAR buffer[STACKWALK_MAX_NAMELEN];
-  if (fileVersion == 0)
-    _snprintf_s(buffer, STACKWALK_MAX_NAMELEN, "%s:%s (%p), size: %d (result: %d), SymType: '%s', PDB: '%s'\n", img, mod, (LPVOID) baseAddr, size, result, symType, pdbName);
-  else
-  {
-    DWORD v4 = (DWORD) fileVersion & 0xFFFF;
-    DWORD v3 = (DWORD) (fileVersion>>16) & 0xFFFF;
-    DWORD v2 = (DWORD) (fileVersion>>32) & 0xFFFF;
-    DWORD v1 = (DWORD) (fileVersion>>48) & 0xFFFF;
-    _snprintf_s(buffer, STACKWALK_MAX_NAMELEN, "%s:%s (%p), size: %d (result: %d), SymType: '%s', PDB: '%s', fileVersion: %d.%d.%d.%d\n", img, mod, (LPVOID) baseAddr, size, result, symType, pdbName, v1, v2, v3, v4);
-  }
-  OnOutput(buffer);
+	CHAR   buffer[STACKWALK_MAX_NAMELEN];
+	size_t maxLen = STACKWALK_MAX_NAMELEN;
+#if _MSC_VER >= 1400
+	maxLen = _TRUNCATE;
+#endif
+	if (fileVersion == 0)
+		_snprintf_s(buffer, maxLen, "%s:%s (%p), size: %d (result: %d), SymType: '%s', PDB: '%s'\n",
+			img, mod, (LPVOID)baseAddr, size, result, symType, pdbName);
+	else
+	{
+		DWORD v4 = (DWORD)(fileVersion & 0xFFFF);
+		DWORD v3 = (DWORD)((fileVersion >> 16) & 0xFFFF);
+		DWORD v2 = (DWORD)((fileVersion >> 32) & 0xFFFF);
+		DWORD v1 = (DWORD)((fileVersion >> 48) & 0xFFFF);
+		_snprintf_s(
+			buffer, maxLen,
+			"%s:%s (%p), size: %d (result: %d), SymType: '%s', PDB: '%s', fileVersion: %d.%d.%d.%d\n",
+			img, mod, (LPVOID)baseAddr, size, result, symType, pdbName, v1, v2, v3, v4);
+	}
+	buffer[STACKWALK_MAX_NAMELEN - 1] = 0; // be sure it is NULL terminated
+	OnOutput(buffer);
 }
 
-void StackWalker::OnCallstackEntry(CallstackEntryType eType, CallstackEntry &entry)
+void StackWalker::OnCallstackEntry(CallstackEntryType eType, CallstackEntry& entry)
 {
-  CHAR buffer[STACKWALK_MAX_NAMELEN];
-  if ( (eType != lastEntry) && (entry.offset != 0) )
-  {
-    if (entry.name[0] == 0)
-      strcpy_s(entry.name, "(function-name not available)");
-    if (entry.undName[0] != 0)
-      strcpy_s(entry.name, entry.undName);
-    if (entry.undFullName[0] != 0)
-      strcpy_s(entry.name, entry.undFullName);
-    if (entry.lineFileName[0] == 0)
-    {
-      strcpy_s(entry.lineFileName, "(filename not available)");
-      if (entry.moduleName[0] == 0)
-        strcpy_s(entry.moduleName, "(module-name not available)");
-      _snprintf_s(buffer, STACKWALK_MAX_NAMELEN, "%p (%s): %s: %s\n", (LPVOID) entry.offset, entry.moduleName, entry.lineFileName, entry.name);
-    }
-    else
-      _snprintf_s(buffer, STACKWALK_MAX_NAMELEN, "%s (%d): %s\n", entry.lineFileName, entry.lineNumber, entry.name);
-    OnOutput(buffer);
-  }
+	CHAR   buffer[STACKWALK_MAX_NAMELEN];
+	size_t maxLen = STACKWALK_MAX_NAMELEN;
+#if _MSC_VER >= 1400
+	maxLen = _TRUNCATE;
+#endif
+	if ((eType != lastEntry) && (entry.offset != 0))
+	{
+		if (entry.name[0] == 0)
+			MyStrCpy(entry.name, STACKWALK_MAX_NAMELEN, "(function-name not available)");
+		if (entry.undName[0] != 0)
+			MyStrCpy(entry.name, STACKWALK_MAX_NAMELEN, entry.undName);
+		if (entry.undFullName[0] != 0)
+			MyStrCpy(entry.name, STACKWALK_MAX_NAMELEN, entry.undFullName);
+		if (entry.lineFileName[0] == 0)
+		{
+			MyStrCpy(entry.lineFileName, STACKWALK_MAX_NAMELEN, "(filename not available)");
+			if (entry.moduleName[0] == 0)
+				MyStrCpy(entry.moduleName, STACKWALK_MAX_NAMELEN, "(module-name not available)");
+			_snprintf_s(buffer, maxLen, "%p (%s): %s: %s\n", (LPVOID)entry.offset, entry.moduleName,
+				entry.lineFileName, entry.name);
+		}
+		else
+			_snprintf_s(buffer, maxLen, "%s (%d): %s\n", entry.lineFileName, entry.lineNumber,
+				entry.name);
+		buffer[STACKWALK_MAX_NAMELEN - 1] = 0;
+		OnOutput(buffer);
+	}
 }
 
 void StackWalker::OnDbgHelpErr(LPCSTR szFuncName, DWORD gle, DWORD64 addr)
 {
-  CHAR buffer[STACKWALK_MAX_NAMELEN];
-  _snprintf_s(buffer, STACKWALK_MAX_NAMELEN, "ERROR: %s, GetLastError: %d (Address: %p)\n", szFuncName, gle, (LPVOID) addr);
-  OnOutput(buffer);
+	CHAR   buffer[STACKWALK_MAX_NAMELEN];
+	size_t maxLen = STACKWALK_MAX_NAMELEN;
+#if _MSC_VER >= 1400
+	maxLen = _TRUNCATE;
+#endif
+	_snprintf_s(buffer, maxLen, "ERROR: %s, GetLastError: %d (Address: %p)\n", szFuncName, gle,
+		(LPVOID)addr);
+	buffer[STACKWALK_MAX_NAMELEN - 1] = 0;
+	OnOutput(buffer);
 }
 
 void StackWalker::OnSymInit(LPCSTR szSearchPath, DWORD symOptions, LPCSTR szUserName)
 {
-  CHAR buffer[STACKWALK_MAX_NAMELEN];
-  _snprintf_s(buffer, STACKWALK_MAX_NAMELEN, "SymInit: Symbol-SearchPath: '%s', symOptions: %d, UserName: '%s'\n", szSearchPath, symOptions, szUserName);
-  OnOutput(buffer);
-  // Also display the OS-version
+	CHAR   buffer[STACKWALK_MAX_NAMELEN];
+	size_t maxLen = STACKWALK_MAX_NAMELEN;
+#if _MSC_VER >= 1400
+	maxLen = _TRUNCATE;
+#endif
+	_snprintf_s(buffer, maxLen, "SymInit: Symbol-SearchPath: '%s', symOptions: %d, UserName: '%s'\n",
+		szSearchPath, symOptions, szUserName);
+	buffer[STACKWALK_MAX_NAMELEN - 1] = 0;
+	OnOutput(buffer);
+	// Also display the OS-version
 #if _MSC_VER <= 1200
-  OSVERSIONINFOA ver;
-  ZeroMemory(&ver, sizeof(OSVERSIONINFOA));
-  ver.dwOSVersionInfoSize = sizeof(ver);
-  if (GetVersionExA(&ver) != FALSE)
-  {
-    _snprintf_s(buffer, STACKWALK_MAX_NAMELEN, "OS-Version: %d.%d.%d (%s)\n", 
-      ver.dwMajorVersion, ver.dwMinorVersion, ver.dwBuildNumber,
-      ver.szCSDVersion);
-    OnOutput(buffer);
-  }
+	OSVERSIONINFOA ver;
+	ZeroMemory(&ver, sizeof(OSVERSIONINFOA));
+	ver.dwOSVersionInfoSize = sizeof(ver);
+	if (GetVersionExA(&ver) != FALSE)
+	{
+		_snprintf_s(buffer, maxLen, "OS-Version: %d.%d.%d (%s)\n", ver.dwMajorVersion,
+			ver.dwMinorVersion, ver.dwBuildNumber, ver.szCSDVersion);
+		buffer[STACKWALK_MAX_NAMELEN - 1] = 0;
+		OnOutput(buffer);
+	}
 #else
-  OSVERSIONINFOEXA ver;
-  ZeroMemory(&ver, sizeof(OSVERSIONINFOEXA));
-  ver.dwOSVersionInfoSize = sizeof(ver);
-  if (GetVersionExA( (OSVERSIONINFOA*) &ver) != FALSE)
-  {
-    _snprintf_s(buffer, STACKWALK_MAX_NAMELEN, "OS-Version: %d.%d.%d (%s) 0x%x-0x%x\n", 
-      ver.dwMajorVersion, ver.dwMinorVersion, ver.dwBuildNumber,
-      ver.szCSDVersion, ver.wSuiteMask, ver.wProductType);
-    OnOutput(buffer);
-  }
+	OSVERSIONINFOEXA ver;
+	ZeroMemory(&ver, sizeof(OSVERSIONINFOEXA));
+	ver.dwOSVersionInfoSize = sizeof(ver);
+#if _MSC_VER >= 1900
+#pragma warning(push)
+#pragma warning(disable : 4996)
+#endif
+	if (GetVersionExA((OSVERSIONINFOA*)&ver) != FALSE)
+	{
+		_snprintf_s(buffer, maxLen, "OS-Version: %d.%d.%d (%s) 0x%x-0x%x\n", ver.dwMajorVersion,
+			ver.dwMinorVersion, ver.dwBuildNumber, ver.szCSDVersion, ver.wSuiteMask,
+			ver.wProductType);
+		buffer[STACKWALK_MAX_NAMELEN - 1] = 0;
+		OnOutput(buffer);
+	}
+#if _MSC_VER >= 1900
+#pragma warning(pop)
+#endif
 #endif
 }
 
 void StackWalker::OnOutput(LPCSTR buffer)
 {
-  OutputDebugStringA(buffer);
+	OutputDebugStringA(buffer);
 }

--- a/Profiler/StackWalker.h
+++ b/Profiler/StackWalker.h
@@ -1,0 +1,189 @@
+/**********************************************************************
+ * 
+ * StackWalker.h
+ *
+ *
+ * History:
+ *  2005-07-27   v1    - First public release on http://www.codeproject.com/
+ *  (for additional changes see History in 'StackWalker.cpp'!
+ *
+ **********************************************************************/
+// #pragma once is supported starting with _MCS_VER 1000, 
+// so we need not to check the version (because we only support _MSC_VER >= 1100)!
+#pragma once
+
+#include <windows.h>
+
+// special defines for VC5/6 (if no actual PSDK is installed):
+#if _MSC_VER < 1300
+typedef unsigned __int64 DWORD64, *PDWORD64;
+#if defined(_WIN64)
+typedef unsigned __int64 SIZE_T, *PSIZE_T;
+#else
+typedef unsigned long SIZE_T, *PSIZE_T;
+#endif
+#endif  // _MSC_VER < 1300
+
+class StackWalkerInternal;  // forward
+class StackWalker
+{
+public:
+  typedef enum StackWalkOptions
+  {
+    // No addition info will be retrived 
+    // (only the address is available)
+    RetrieveNone = 0,
+    
+    // Try to get the symbol-name
+    RetrieveSymbol = 1,
+    
+    // Try to get the line for this symbol
+    RetrieveLine = 2,
+    
+    // Try to retrieve the module-infos
+    RetrieveModuleInfo = 4,
+    
+    // Also retrieve the version for the DLL/EXE
+    RetrieveFileVersion = 8,
+    
+    // Contains all the abouve
+    RetrieveVerbose = 0xF,
+    
+    // Generate a "good" symbol-search-path
+    SymBuildPath = 0x10,
+    
+    // Also use the public Microsoft-Symbol-Server
+    SymUseSymSrv = 0x20,
+    
+    // Contains all the abouve "Sym"-options
+    SymAll = 0x30,
+    
+    // Contains all options (default)
+    OptionsAll = 0x3F
+  } StackWalkOptions;
+
+  StackWalker(
+    int options = OptionsAll, // 'int' is by design, to combine the enum-flags
+    LPCSTR szSymPath = NULL, 
+    DWORD dwProcessId = GetCurrentProcessId(), 
+    HANDLE hProcess = GetCurrentProcess()
+    );
+  StackWalker(DWORD dwProcessId, HANDLE hProcess);
+  virtual ~StackWalker();
+
+  typedef BOOL (__stdcall *PReadProcessMemoryRoutine)(
+    HANDLE      hProcess,
+    DWORD64     qwBaseAddress,
+    PVOID       lpBuffer,
+    DWORD       nSize,
+    LPDWORD     lpNumberOfBytesRead,
+    LPVOID      pUserData  // optional data, which was passed in "ShowCallstack"
+    );
+
+  BOOL LoadModules();
+
+  BOOL ShowCallstack(
+    HANDLE hThread = GetCurrentThread(), 
+    const CONTEXT *context = NULL, 
+    PReadProcessMemoryRoutine readMemoryFunction = NULL,
+    LPVOID pUserData = NULL  // optional to identify some data in the 'readMemoryFunction'-callback
+    );
+
+#if _MSC_VER >= 1300
+// due to some reasons, the "STACKWALK_MAX_NAMELEN" must be declared as "public" 
+// in older compilers in order to use it... starting with VC7 we can declare it as "protected"
+protected:
+#endif
+	enum { STACKWALK_MAX_NAMELEN = 1024 }; // max name length for found symbols
+
+protected:
+  // Entry for each Callstack-Entry
+  typedef struct CallstackEntry
+  {
+    DWORD64 offset;  // if 0, we have no valid entry
+    CHAR name[STACKWALK_MAX_NAMELEN];
+    CHAR undName[STACKWALK_MAX_NAMELEN];
+    CHAR undFullName[STACKWALK_MAX_NAMELEN];
+    DWORD64 offsetFromSmybol;
+    DWORD offsetFromLine;
+    DWORD lineNumber;
+    CHAR lineFileName[STACKWALK_MAX_NAMELEN];
+    DWORD symType;
+    LPCSTR symTypeString;
+    CHAR moduleName[STACKWALK_MAX_NAMELEN];
+    DWORD64 baseOfImage;
+    CHAR loadedImageName[STACKWALK_MAX_NAMELEN];
+  } CallstackEntry;
+
+  typedef enum CallstackEntryType {firstEntry, nextEntry, lastEntry};
+
+  virtual void OnSymInit(LPCSTR szSearchPath, DWORD symOptions, LPCSTR szUserName);
+  virtual void OnLoadModule(LPCSTR img, LPCSTR mod, DWORD64 baseAddr, DWORD size, DWORD result, LPCSTR symType, LPCSTR pdbName, ULONGLONG fileVersion);
+  virtual void OnCallstackEntry(CallstackEntryType eType, CallstackEntry &entry);
+  virtual void OnDbgHelpErr(LPCSTR szFuncName, DWORD gle, DWORD64 addr);
+  virtual void OnOutput(LPCSTR szText);
+
+  StackWalkerInternal *m_sw;
+  HANDLE m_hProcess;
+  DWORD m_dwProcessId;
+  BOOL m_modulesLoaded;
+  LPSTR m_szSymPath;
+
+  int m_options;
+
+  static BOOL __stdcall myReadProcMem(HANDLE hProcess, DWORD64 qwBaseAddress, PVOID lpBuffer, DWORD nSize, LPDWORD lpNumberOfBytesRead);
+
+  friend StackWalkerInternal;
+};
+
+
+// The "ugly" assembler-implementation is needed for systems before XP
+// If you have a new PSDK and you only compile for XP and later, then you can use 
+// the "RtlCaptureContext"
+// Currently there is no define which determines the PSDK-Version... 
+// So we just use the compiler-version (and assumes that the PSDK is 
+// the one which was installed by the VS-IDE)
+
+// INFO: If you want, you can use the RtlCaptureContext if you only target XP and later...
+//       But I currently use it in x64/IA64 environments...
+//#if defined(_M_IX86) && (_WIN32_WINNT <= 0x0500) && (_MSC_VER < 1400)
+
+#if defined(_M_IX86)
+#ifdef CURRENT_THREAD_VIA_EXCEPTION
+// TODO: The following is not a "good" implementation, 
+// because the callstack is only valid in the "__except" block...
+#define GET_CURRENT_CONTEXT(c, contextFlags) \
+  do { \
+    memset(&c, 0, sizeof(CONTEXT)); \
+    EXCEPTION_POINTERS *pExp = NULL; \
+    __try { \
+      throw 0; \
+    } __except( ( (pExp = GetExceptionInformation()) ? EXCEPTION_EXECUTE_HANDLER : EXCEPTION_EXECUTE_HANDLER)) {} \
+    if (pExp != NULL) \
+      memcpy(&c, pExp->ContextRecord, sizeof(CONTEXT)); \
+      c.ContextFlags = contextFlags; \
+  } while(0);
+#else
+// The following should be enough for walking the callstack...
+#define GET_CURRENT_CONTEXT(c, contextFlags) \
+  do { \
+    memset(&c, 0, sizeof(CONTEXT)); \
+    c.ContextFlags = contextFlags; \
+    __asm    call x \
+    __asm x: pop eax \
+    __asm    mov c.Eip, eax \
+    __asm    mov c.Ebp, ebp \
+    __asm    mov c.Esp, esp \
+  } while(0);
+#endif
+
+#else
+
+// The following is defined for x86 (XP and higher), x64 and IA64:
+#define GET_CURRENT_CONTEXT(c, contextFlags) \
+  do { \
+    memset(&c, 0, sizeof(CONTEXT)); \
+    c.ContextFlags = contextFlags; \
+    RtlCaptureContext(&c); \
+} while(0);
+#endif

--- a/Profiler/StackWalker.h
+++ b/Profiler/StackWalker.h
@@ -1,18 +1,51 @@
+#ifndef __STACKWALKER_H__
+#define __STACKWALKER_H__
+
+#if defined(_MSC_VER)
+
 /**********************************************************************
- * 
- * StackWalker.h
- *
- *
- * History:
- *  2005-07-27   v1    - First public release on http://www.codeproject.com/
- *  (for additional changes see History in 'StackWalker.cpp'!
- *
- **********************************************************************/
-// #pragma once is supported starting with _MCS_VER 1000, 
+*
+* StackWalker.h
+*
+*
+*
+* LICENSE (http://www.opensource.org/licenses/bsd-license.php)
+*
+*   Copyright (c) 2005-2009, Jochen Kalmbach
+*   All rights reserved.
+*
+*   Redistribution and use in source and binary forms, with or without modification,
+*   are permitted provided that the following conditions are met:
+*
+*   Redistributions of source code must retain the above copyright notice,
+*   this list of conditions and the following disclaimer.
+*   Redistributions in binary form must reproduce the above copyright notice,
+*   this list of conditions and the following disclaimer in the documentation
+*   and/or other materials provided with the distribution.
+*   Neither the name of Jochen Kalmbach nor the names of its contributors may be
+*   used to endorse or promote products derived from this software without
+*   specific prior written permission.
+*   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+*   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+*   THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+*   ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+*   FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+*   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+*   LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+*   ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+*   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+*   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+* **********************************************************************/
+// #pragma once is supported starting with _MSC_VER 1000,
 // so we need not to check the version (because we only support _MSC_VER >= 1100)!
 #pragma once
 
 #include <windows.h>
+
+#if _MSC_VER >= 1900
+#pragma warning(disable : 4091)
+#endif
 
 // special defines for VC5/6 (if no actual PSDK is installed):
 #if _MSC_VER < 1300
@@ -22,168 +55,201 @@ typedef unsigned __int64 SIZE_T, *PSIZE_T;
 #else
 typedef unsigned long SIZE_T, *PSIZE_T;
 #endif
-#endif  // _MSC_VER < 1300
+#endif // _MSC_VER < 1300
 
-class StackWalkerInternal;  // forward
+class StackWalkerInternal; // forward
 class StackWalker
 {
 public:
-  typedef enum StackWalkOptions
-  {
-    // No addition info will be retrived 
-    // (only the address is available)
-    RetrieveNone = 0,
-    
-    // Try to get the symbol-name
-    RetrieveSymbol = 1,
-    
-    // Try to get the line for this symbol
-    RetrieveLine = 2,
-    
-    // Try to retrieve the module-infos
-    RetrieveModuleInfo = 4,
-    
-    // Also retrieve the version for the DLL/EXE
-    RetrieveFileVersion = 8,
-    
-    // Contains all the abouve
-    RetrieveVerbose = 0xF,
-    
-    // Generate a "good" symbol-search-path
-    SymBuildPath = 0x10,
-    
-    // Also use the public Microsoft-Symbol-Server
-    SymUseSymSrv = 0x20,
-    
-    // Contains all the abouve "Sym"-options
-    SymAll = 0x30,
-    
-    // Contains all options (default)
-    OptionsAll = 0x3F
-  } StackWalkOptions;
+	typedef enum StackWalkOptions
+	{
+		// No addition info will be retrieved
+		// (only the address is available)
+		RetrieveNone = 0,
 
-  StackWalker(
-    int options = OptionsAll, // 'int' is by design, to combine the enum-flags
-    LPCSTR szSymPath = NULL, 
-    DWORD dwProcessId = GetCurrentProcessId(), 
-    HANDLE hProcess = GetCurrentProcess()
-    );
-  StackWalker(DWORD dwProcessId, HANDLE hProcess);
-  virtual ~StackWalker();
+		// Try to get the symbol-name
+		RetrieveSymbol = 1,
 
-  typedef BOOL (__stdcall *PReadProcessMemoryRoutine)(
-    HANDLE      hProcess,
-    DWORD64     qwBaseAddress,
-    PVOID       lpBuffer,
-    DWORD       nSize,
-    LPDWORD     lpNumberOfBytesRead,
-    LPVOID      pUserData  // optional data, which was passed in "ShowCallstack"
-    );
+		// Try to get the line for this symbol
+		RetrieveLine = 2,
 
-  BOOL LoadModules();
+		// Try to retrieve the module-infos
+		RetrieveModuleInfo = 4,
 
-  BOOL ShowCallstack(
-    HANDLE hThread = GetCurrentThread(), 
-    const CONTEXT *context = NULL, 
-    PReadProcessMemoryRoutine readMemoryFunction = NULL,
-    LPVOID pUserData = NULL  // optional to identify some data in the 'readMemoryFunction'-callback
-    );
+		// Also retrieve the version for the DLL/EXE
+		RetrieveFileVersion = 8,
+
+		// Contains all the above
+		RetrieveVerbose = 0xF,
+
+		// Generate a "good" symbol-search-path
+		SymBuildPath = 0x10,
+
+		// Also use the public Microsoft-Symbol-Server
+		SymUseSymSrv = 0x20,
+
+		// Contains all the above "Sym"-options
+		SymAll = 0x30,
+
+		// Contains all options (default)
+		OptionsAll = 0x3F
+	} StackWalkOptions;
+
+	StackWalker(int    options = OptionsAll, // 'int' is by design, to combine the enum-flags
+		LPCSTR szSymPath = NULL,
+		DWORD  dwProcessId = GetCurrentProcessId(),
+		HANDLE hProcess = GetCurrentProcess());
+	StackWalker(DWORD dwProcessId, HANDLE hProcess);
+	virtual ~StackWalker();
+
+	typedef BOOL(__stdcall* PReadProcessMemoryRoutine)(
+		HANDLE  hProcess,
+		DWORD64 qwBaseAddress,
+		PVOID   lpBuffer,
+		DWORD   nSize,
+		LPDWORD lpNumberOfBytesRead,
+		LPVOID  pUserData // optional data, which was passed in "ShowCallstack"
+		);
+
+	BOOL LoadModules();
+
+	BOOL ShowCallstack(
+		HANDLE                    hThread = GetCurrentThread(),
+		const CONTEXT*            context = NULL,
+		PReadProcessMemoryRoutine readMemoryFunction = NULL,
+		LPVOID pUserData = NULL // optional to identify some data in the 'readMemoryFunction'-callback
+	);
+
+	BOOL ShowObject(LPVOID pObject);
 
 #if _MSC_VER >= 1300
-// due to some reasons, the "STACKWALK_MAX_NAMELEN" must be declared as "public" 
-// in older compilers in order to use it... starting with VC7 we can declare it as "protected"
+	// due to some reasons, the "STACKWALK_MAX_NAMELEN" must be declared as "public"
+	// in older compilers in order to use it... starting with VC7 we can declare it as "protected"
 protected:
 #endif
-	enum { STACKWALK_MAX_NAMELEN = 1024 }; // max name length for found symbols
+	enum
+	{
+		STACKWALK_MAX_NAMELEN = 1024
+	}; // max name length for found symbols
 
 protected:
-  // Entry for each Callstack-Entry
-  typedef struct CallstackEntry
-  {
-    DWORD64 offset;  // if 0, we have no valid entry
-    CHAR name[STACKWALK_MAX_NAMELEN];
-    CHAR undName[STACKWALK_MAX_NAMELEN];
-    CHAR undFullName[STACKWALK_MAX_NAMELEN];
-    DWORD64 offsetFromSmybol;
-    DWORD offsetFromLine;
-    DWORD lineNumber;
-    CHAR lineFileName[STACKWALK_MAX_NAMELEN];
-    DWORD symType;
-    LPCSTR symTypeString;
-    CHAR moduleName[STACKWALK_MAX_NAMELEN];
-    DWORD64 baseOfImage;
-    CHAR loadedImageName[STACKWALK_MAX_NAMELEN];
-  } CallstackEntry;
+	// Entry for each Callstack-Entry
+	typedef struct CallstackEntry
+	{
+		DWORD64 offset; // if 0, we have no valid entry
+		CHAR    name[STACKWALK_MAX_NAMELEN];
+		CHAR    undName[STACKWALK_MAX_NAMELEN];
+		CHAR    undFullName[STACKWALK_MAX_NAMELEN];
+		DWORD64 offsetFromSmybol;
+		DWORD   offsetFromLine;
+		DWORD   lineNumber;
+		CHAR    lineFileName[STACKWALK_MAX_NAMELEN];
+		DWORD   symType;
+		LPCSTR  symTypeString;
+		CHAR    moduleName[STACKWALK_MAX_NAMELEN];
+		DWORD64 baseOfImage;
+		CHAR    loadedImageName[STACKWALK_MAX_NAMELEN];
+	} CallstackEntry;
 
-  typedef enum CallstackEntryType {firstEntry, nextEntry, lastEntry};
+	typedef enum CallstackEntryType
+	{
+		firstEntry,
+		nextEntry,
+		lastEntry
+	} CallstackEntryType;
 
-  virtual void OnSymInit(LPCSTR szSearchPath, DWORD symOptions, LPCSTR szUserName);
-  virtual void OnLoadModule(LPCSTR img, LPCSTR mod, DWORD64 baseAddr, DWORD size, DWORD result, LPCSTR symType, LPCSTR pdbName, ULONGLONG fileVersion);
-  virtual void OnCallstackEntry(CallstackEntryType eType, CallstackEntry &entry);
-  virtual void OnDbgHelpErr(LPCSTR szFuncName, DWORD gle, DWORD64 addr);
-  virtual void OnOutput(LPCSTR szText);
+	virtual void OnSymInit(LPCSTR szSearchPath, DWORD symOptions, LPCSTR szUserName);
+	virtual void OnLoadModule(LPCSTR    img,
+		LPCSTR    mod,
+		DWORD64   baseAddr,
+		DWORD     size,
+		DWORD     result,
+		LPCSTR    symType,
+		LPCSTR    pdbName,
+		ULONGLONG fileVersion);
+	virtual void OnCallstackEntry(CallstackEntryType eType, CallstackEntry& entry);
+	virtual void OnDbgHelpErr(LPCSTR szFuncName, DWORD gle, DWORD64 addr);
+	virtual void OnOutput(LPCSTR szText);
 
-  StackWalkerInternal *m_sw;
-  HANDLE m_hProcess;
-  DWORD m_dwProcessId;
-  BOOL m_modulesLoaded;
-  LPSTR m_szSymPath;
+	StackWalkerInternal* m_sw;
+	HANDLE               m_hProcess;
+	DWORD                m_dwProcessId;
+	BOOL                 m_modulesLoaded;
+	LPSTR                m_szSymPath;
 
-  int m_options;
+	int m_options;
+	int m_MaxRecursionCount;
 
-  static BOOL __stdcall myReadProcMem(HANDLE hProcess, DWORD64 qwBaseAddress, PVOID lpBuffer, DWORD nSize, LPDWORD lpNumberOfBytesRead);
+	static BOOL __stdcall myReadProcMem(HANDLE  hProcess,
+		DWORD64 qwBaseAddress,
+		PVOID   lpBuffer,
+		DWORD   nSize,
+		LPDWORD lpNumberOfBytesRead);
 
-  friend StackWalkerInternal;
-};
+	friend StackWalkerInternal;
+}; // class StackWalker
 
+   // The "ugly" assembler-implementation is needed for systems before XP
+   // If you have a new PSDK and you only compile for XP and later, then you can use
+   // the "RtlCaptureContext"
+   // Currently there is no define which determines the PSDK-Version...
+   // So we just use the compiler-version (and assumes that the PSDK is
+   // the one which was installed by the VS-IDE)
 
-// The "ugly" assembler-implementation is needed for systems before XP
-// If you have a new PSDK and you only compile for XP and later, then you can use 
-// the "RtlCaptureContext"
-// Currently there is no define which determines the PSDK-Version... 
-// So we just use the compiler-version (and assumes that the PSDK is 
-// the one which was installed by the VS-IDE)
-
-// INFO: If you want, you can use the RtlCaptureContext if you only target XP and later...
-//       But I currently use it in x64/IA64 environments...
-//#if defined(_M_IX86) && (_WIN32_WINNT <= 0x0500) && (_MSC_VER < 1400)
+   // INFO: If you want, you can use the RtlCaptureContext if you only target XP and later...
+   //       But I currently use it in x64/IA64 environments...
+   //#if defined(_M_IX86) && (_WIN32_WINNT <= 0x0500) && (_MSC_VER < 1400)
 
 #if defined(_M_IX86)
 #ifdef CURRENT_THREAD_VIA_EXCEPTION
-// TODO: The following is not a "good" implementation, 
-// because the callstack is only valid in the "__except" block...
-#define GET_CURRENT_CONTEXT(c, contextFlags) \
-  do { \
-    memset(&c, 0, sizeof(CONTEXT)); \
-    EXCEPTION_POINTERS *pExp = NULL; \
-    __try { \
-      throw 0; \
-    } __except( ( (pExp = GetExceptionInformation()) ? EXCEPTION_EXECUTE_HANDLER : EXCEPTION_EXECUTE_HANDLER)) {} \
-    if (pExp != NULL) \
-      memcpy(&c, pExp->ContextRecord, sizeof(CONTEXT)); \
-      c.ContextFlags = contextFlags; \
-  } while(0);
+   // TODO: The following is not a "good" implementation,
+   // because the callstack is only valid in the "__except" block...
+#define GET_CURRENT_CONTEXT_STACKWALKER_CODEPLEX(c, contextFlags)               \
+  do                                                                            \
+  {                                                                             \
+    memset(&c, 0, sizeof(CONTEXT));                                             \
+    EXCEPTION_POINTERS* pExp = NULL;                                            \
+    __try                                                                       \
+    {                                                                           \
+      throw 0;                                                                  \
+    }                                                                           \
+    __except (((pExp = GetExceptionInformation()) ? EXCEPTION_EXECUTE_HANDLER   \
+                                                  : EXCEPTION_EXECUTE_HANDLER)) \
+    {                                                                           \
+    }                                                                           \
+    if (pExp != NULL)                                                           \
+      memcpy(&c, pExp->ContextRecord, sizeof(CONTEXT));                         \
+    c.ContextFlags = contextFlags;                                              \
+  } while (0);
 #else
-// The following should be enough for walking the callstack...
-#define GET_CURRENT_CONTEXT(c, contextFlags) \
-  do { \
-    memset(&c, 0, sizeof(CONTEXT)); \
-    c.ContextFlags = contextFlags; \
-    __asm    call x \
-    __asm x: pop eax \
-    __asm    mov c.Eip, eax \
-    __asm    mov c.Ebp, ebp \
-    __asm    mov c.Esp, esp \
-  } while(0);
+   // clang-format off
+   // The following should be enough for walking the callstack...
+#define GET_CURRENT_CONTEXT_STACKWALKER_CODEPLEX(c, contextFlags) \
+  do                                                              \
+  {                                                               \
+    memset(&c, 0, sizeof(CONTEXT));                               \
+    c.ContextFlags = contextFlags;                                \
+    __asm    call x                                               \
+    __asm x: pop eax                                              \
+    __asm    mov c.Eip, eax                                       \
+    __asm    mov c.Ebp, ebp                                       \
+    __asm    mov c.Esp, esp                                       \
+  } while (0)
+   // clang-format on
 #endif
 
 #else
 
-// The following is defined for x86 (XP and higher), x64 and IA64:
-#define GET_CURRENT_CONTEXT(c, contextFlags) \
-  do { \
-    memset(&c, 0, sizeof(CONTEXT)); \
-    c.ContextFlags = contextFlags; \
-    RtlCaptureContext(&c); \
-} while(0);
+   // The following is defined for x86 (XP and higher), x64 and IA64:
+#define GET_CURRENT_CONTEXT_STACKWALKER_CODEPLEX(c, contextFlags) \
+  do                                                              \
+  {                                                               \
+    memset(&c, 0, sizeof(CONTEXT));                               \
+    c.ContextFlags = contextFlags;                                \
+    RtlCaptureContext(&c);                                        \
+  } while (0);
 #endif
+
+#endif //defined(_MSC_VER)
+
+#endif // __STACKWALKER_H__

--- a/Profiler/Stacktrace.cpp
+++ b/Profiler/Stacktrace.cpp
@@ -1,0 +1,251 @@
+#include "Stacktrace.h"
+#include <stdio.h>
+#include <atlbase.h>
+#include "dbghelp.h"
+#include <signal.h>
+#include "Debug.h"
+#include <signal.h>
+#include <windows.h>
+#include <atomic>
+#include <string>
+#include <exception>
+
+/** Where to write the stacktrace in case of a crash. */
+static std::string OUTPUT_FILE_PATH("C:\\Users\\Public\\teamscale-dotnet-profiler.minidump");
+static HANDLE OUTPUT_FILE = INVALID_HANDLE_VALUE;
+
+/*// based on dbghelp.h
+typedef BOOL(WINAPI *MINIDUMPWRITEDUMP)(HANDLE hProcess, DWORD dwPid, HANDLE hFile, MINIDUMP_TYPE DumpType,
+	CONST PMINIDUMP_EXCEPTION_INFORMATION ExceptionParam,
+	CONST PMINIDUMP_USER_STREAM_INFORMATION UserStreamParam,
+	CONST PMINIDUMP_CALLBACK_INFORMATION CallbackParam
+	);
+
+class StackWalker2 : public StackWalker
+{
+public:
+	std::string output;
+
+	void OnOutput(LPCSTR text) {
+		output += text;
+		output += "\r\n";
+	}
+};
+
+static std::string getStackTrace()
+{
+	StackWalker2 stackWalker;
+	stackWalker.ShowCallstack();
+	return stackWalker.output;
+}
+
+void abortHandler(int signum)
+{
+	Debug::log("abrt");
+	const char* name = NULL;
+	switch (signum) {
+	case SIGABRT: name = "SIGABRT";  break;
+	case SIGSEGV: name = "SIGSEGV";  break;
+	case SIGILL:  name = "SIGILL";   break;
+	case SIGFPE:  name = "SIGFPE";   break;
+	}
+
+	std::string message;
+
+	if (name) {
+		message = "Caught signal " + std::to_string(signum) + " (" + name + ")\r\n";
+	}
+	else {
+		message = "Caught signal " + std::to_string(signum) + "\r\n";
+	}
+
+	message += getStackTrace();
+
+	HANDLE logFile = CreateFile(OUTPUT_FILE.c_str(), GENERIC_WRITE, FILE_SHARE_READ,
+		NULL, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
+	WriteFile(logFile, message.c_str(), (DWORD)strlen(message.c_str()), NULL, NULL);
+
+	exit(signum);
+}
+
+void Stacktrace::printStacktraceOnAbort()
+{
+	SetUnhandledExceptionFilter(topLevelFilter);
+}
+
+long Stacktrace::topLevelFilter(struct _EXCEPTION_POINTERS *pExceptionInfo)
+{
+	Debug::log("abrt");
+	HMODULE hDll = LoadLibrary("DBGHELP.DLL");
+	LPCTSTR szResult = NULL;
+
+	if (!hDll)
+	{
+		Debug::log("Couldn't find dbghelp.dll\n");
+		return EXCEPTION_CONTINUE_SEARCH;
+	}
+
+	MINIDUMPWRITEDUMP pDump = (MINIDUMPWRITEDUMP)::GetProcAddress(hDll, "MiniDumpWriteDump");
+	if (!pDump)
+	{
+		Debug::log("Couldn't find MiniDumpWriteDump function\n");
+		return EXCEPTION_CONTINUE_SEARCH;
+	}
+
+	HANDLE hFile = ::CreateFile(OUTPUT_FILE.c_str(), GENERIC_WRITE, FILE_SHARE_WRITE, NULL, CREATE_ALWAYS,
+		FILE_ATTRIBUTE_NORMAL, NULL);
+	if (hFile == INVALID_HANDLE_VALUE)
+	{
+		Debug::log("Couldn't create minidump file\n");
+		return EXCEPTION_CONTINUE_SEARCH;
+	}
+
+	_MINIDUMP_EXCEPTION_INFORMATION ExInfo;
+
+	ExInfo.ThreadId = GetCurrentThreadId();
+	ExInfo.ExceptionPointers = pExceptionInfo;
+	ExInfo.ClientPointers = NULL;
+
+	BOOL bOK = pDump(GetCurrentProcess(), GetCurrentProcessId(), hFile, (MINIDUMP_TYPE)(MiniDumpNormal | MiniDumpWithDataSegs), &ExInfo, NULL, NULL);
+
+	LONG returnValue;
+	if (bOK)
+	{
+		returnValue = EXCEPTION_EXECUTE_HANDLER;
+	}
+	else
+	{
+		Debug::log("Failed to write minidump file\n");
+		returnValue = EXCEPTION_CONTINUE_SEARCH;
+	}
+
+	CloseHandle(hFile);
+	return returnValue;
+}*/
+
+/** Taken from https://randomascii.wordpress.com/2012/07/05/when-even-crashing-doesnt-work/ */
+static void EnableCrashingOnCrashes()
+{
+	typedef BOOL(WINAPI *tGetPolicy)(LPDWORD lpFlags);
+	typedef BOOL(WINAPI *tSetPolicy)(DWORD dwFlags);
+	const DWORD EXCEPTION_SWALLOWING = 0x1;
+
+	HMODULE kernel32 = LoadLibraryA("kernel32.dll");
+	tGetPolicy pGetPolicy = (tGetPolicy)GetProcAddress(kernel32,
+		"GetProcessUserModeExceptionPolicy");
+	tSetPolicy pSetPolicy = (tSetPolicy)GetProcAddress(kernel32,
+		"SetProcessUserModeExceptionPolicy");
+	if (pGetPolicy && pSetPolicy)
+	{
+		DWORD dwFlags;
+		if (pGetPolicy(&dwFlags))
+		{
+			// Turn off the filter
+			pSetPolicy(dwFlags & ~EXCEPTION_SWALLOWING);
+		}
+	}
+	BOOL insanity = FALSE;
+	SetUserObjectInformationA(GetCurrentProcess(),
+		UOI_TIMERPROC_EXCEPTION_SUPPRESSION,
+		&insanity, sizeof(insanity));
+}
+
+/** Taken from http://blog.kalmbach-software.de/2013/05/23/improvedpreventsetunhandledexceptionfilter/ */
+static BOOL PreventSetUnhandledExceptionFilter()
+{
+	HMODULE hKernel32 = LoadLibrary(_T("kernel32.dll"));
+	if (hKernel32 == NULL) return FALSE;
+	void *pOrgEntry = GetProcAddress(hKernel32, "SetUnhandledExceptionFilter");
+	if (pOrgEntry == NULL) return FALSE;
+
+#ifdef _M_IX86
+	// Code for x86:
+	// 33 C0                xor         eax,eax
+	// C2 04 00             ret         4
+	unsigned char szExecute[] = { 0x33, 0xC0, 0xC2, 0x04, 0x00 };
+#elif _M_X64
+	// 33 C0                xor         eax,eax
+	// C3                   ret
+	unsigned char szExecute[] = { 0x33, 0xC0, 0xC3 };
+#else
+#error "The following code only works for x86 and x64!"
+#endif
+
+	SIZE_T bytesWritten = 0;
+	BOOL bRet = WriteProcessMemory(GetCurrentProcess(),
+		pOrgEntry, szExecute, sizeof(szExecute), &bytesWritten);
+	return bRet;
+}
+
+static void exceptionHandler(EXCEPTION_POINTERS* excpInfo)
+{
+	std::string message = "handling...";
+	WriteFile(OUTPUT_FILE, message.c_str(), (DWORD)strlen(message.c_str()), NULL, NULL);
+}
+
+static std::atomic_bool exceptionHandlerRan(false);
+static LONG WINAPI unhandledException(EXCEPTION_POINTERS* excpInfo = NULL)
+{
+	bool handlerAlreadyRan = exceptionHandlerRan.exchange(true);
+	if (handlerAlreadyRan) {
+		return 0;
+	}
+
+	if (!excpInfo == NULL)
+	{
+		__try // Generate exception to get proper context in dump
+		{
+			RaiseException(EXCEPTION_BREAKPOINT, 0, 0, NULL);
+		}
+		__except (exceptionHandler(GetExceptionInformation()), EXCEPTION_EXECUTE_HANDLER)
+		{
+		}
+	}
+	else
+	{
+		exceptionHandler(excpInfo);
+	}
+
+	return 0;
+}
+
+static void invalidParameter(const wchar_t* expr, const wchar_t* func,
+	const wchar_t* file, unsigned int line, uintptr_t reserved)
+{
+	unhandledException();
+}
+
+static void pureVirtualCall()
+{
+	unhandledException();
+}
+
+static void sigAbortHandler(int sig)
+{
+	// this is required, otherwise if there is another thread
+	// simultaneously tries to abort process will be terminated
+	signal(SIGABRT, sigAbortHandler);
+	unhandledException();
+}
+
+static void terminateHandler() {
+	unhandledException();
+}
+
+/** Taken from https://stackoverflow.com/a/48817594/1396068 */
+void Stacktrace::printStacktraceOnAbort()
+{
+	/*OUTPUT_FILE = CreateFile(OUTPUT_FILE_PATH.c_str(), GENERIC_WRITE, FILE_SHARE_WRITE, NULL, CREATE_ALWAYS,
+		FILE_ATTRIBUTE_NORMAL, NULL);
+
+	SetErrorMode(SEM_FAILCRITICALERRORS | SEM_NOGPFAULTERRORBOX);
+	SetUnhandledExceptionFilter(unhandledException);
+	_set_invalid_parameter_handler(invalidParameter);
+	_set_purecall_handler(pureVirtualCall);
+	signal(SIGABRT, sigAbortHandler);
+	_set_abort_behavior(0, 0);
+	std::set_terminate(terminateHandler);
+	std::set_unexpected(terminateHandler);
+	EnableCrashingOnCrashes();
+	PreventSetUnhandledExceptionFilter();*/
+}

--- a/Profiler/Stacktrace.h
+++ b/Profiler/Stacktrace.h
@@ -1,0 +1,8 @@
+#pragma once
+#include <string>
+
+class Stacktrace
+{
+public:
+	static void printStacktraceOnAbort();
+};

--- a/Profiler/Stacktrace.h
+++ b/Profiler/Stacktrace.h
@@ -1,8 +1,0 @@
-#pragma once
-#include <string>
-
-class Stacktrace
-{
-public:
-	static void printStacktraceOnAbort();
-};

--- a/documentation/userguide.md
+++ b/documentation/userguide.md
@@ -119,6 +119,7 @@ The profiler has several configuration options that can either be set as environ
 | COR_PROFILER_EAGERNESS            | Number, default `0`                      | Enable eager writing of traces after the specified amount of method calls (i.e. write to disk immediately). This should only be used in conjunction with light mode. |
 | COR_PROFILER_PROCESS              | String (optional)                        | The (case-insensitive) name of the executable that should be profiled, e.g. `w3wp.exe`. All other executables will be ignored. |
 | COR_PROFILER_DUMP_ENVIRONMENT     | `1` or `0`, default `0`                  | Print all environment variables of the profiled process in the trace file. |
+| COR_PROFILER_IGNOR_EXCEPTIONS     | `1` or `0`, default `0`                  | Causes all exceptions in the profiler code to be swallowed. For debugging only. |
 
 Please note that the profiler is **also** configured with variables starting with the `COR_PROFILER_` prefix in case of .NET Core applications.
 

--- a/documentation/userguide.md
+++ b/documentation/userguide.md
@@ -158,6 +158,23 @@ Things to check if no trace files are written:
 * IIS: Is the application pool set to pick up the environment of its user?
 * IIS: Did you recycle the application pool?
 
+In case the application doesn't start at all, please check the file `C:\Users\Public\profiler_debug.log`.
+It may contain stack traces in case the profiler crashed.
+
+## Debugging Profiler crashes
+
+If the debug log does not contain enough useful information, you can generate a minidump
+to debug profiler crashes with WinDbg. To enable mini dumps, run the following as a `.reg` file:
+
+    Windows Registry Editor Version 5.00
+
+    [HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps]
+    "DumpFolder"="C:\\Users\\Public"
+    "DumpType"=dword:00000001
+    "DumpCount"=dword:0000000a
+
+A `.dmp` file will be generated in `C:\Users\Public`. You can set `DumpType` to `2` to get a full dump instead.
+This may, however, be a rather large file since the entire program's heap will be dumped.
 
 
 # Automatic Trace Upload

--- a/third-party.licenses
+++ b/third-party.licenses
@@ -1,0 +1,29 @@
+License of the StackWalker library:
+
+LICENSE (http://www.opensource.org/licenses/bsd-license.php)
+
+Copyright (c) 2005-2009, Jochen Kalmbach
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice,
+this list of conditions and the following disclaimer.
+Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+Neither the name of Jochen Kalmbach nor the names of its contributors may be
+used to endorse or promote products derived from this software without
+specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+


### PR DESCRIPTION
Fixes #55

- [ ] Tests written
- [x] Documentation updated

Since this error handling is inherently untestable, I instead tested this manually by introducing a simple segfault into the profiler. I tested both with and without the IGNORE_EXCEPTIONS variable.

I verified that the resulting stack traces are readable and contain the function names. This, however, requires that the .pdb files are present next to the .dll files