### PR TITLE
Trigger upload on profiler shutdown.

### DIFF
--- a/Profiler/CProfilerCallback.cpp
+++ b/Profiler/CProfilerCallback.cpp
@@ -62,7 +62,7 @@ HRESULT CProfilerCallback::InitializeImplementation(IUnknown* pICorProfilerInfoU
 
 	if (config.shouldStartUploadDaemon()) {
 		log.info("Starting upload deamon");
-		createDaemon().launch(&log);
+		createDaemon().launch(log);
 	}
 
 	char appPool[BUFFER_SIZE];

--- a/Profiler/CProfilerCallback.cpp
+++ b/Profiler/CProfilerCallback.cpp
@@ -110,7 +110,6 @@ void CProfilerCallback::dumpEnvironment() {
 
 void CProfilerCallback::startUploadDeamon() {
 	std::string profilerPath = StringUtils::removeLastPartOfPath(WindowsUtils::getConfigValueFromEnvironment("PATH"));
-	std::string traceDirectory = StringUtils::removeLastPartOfPath(log.getLogFilePath());
 
 	UploadDaemon daemon(profilerPath, &log);
 	daemon.launch();

--- a/Profiler/CProfilerCallback.cpp
+++ b/Profiler/CProfilerCallback.cpp
@@ -1,6 +1,5 @@
 #include "CProfilerCallback.h"
 #include "version.h"
-#include "UploadDaemon.h"
 #include "utils/StringUtils.h"
 #include "utils/WindowsUtils.h"
 #include "utils/Debug.h"

--- a/Profiler/CProfilerCallback.h
+++ b/Profiler/CProfilerCallback.h
@@ -9,6 +9,7 @@
 #include <vector>
 #include <map>
 #include <set>
+#include "UploadDaemon.h"
 
 /**
  * Coverage profiler class. Implements JIT event hooks to record method
@@ -106,11 +107,11 @@ private:
 
 	void initializeConfig();
 
+	/** Returns a proxy for the upload daemon process */
+	UploadDaemon createDaemon();
+
 	/** Create method info object for a function id. */
 	HRESULT getFunctionInfo(FunctionID functionID, FunctionInfo* info);
-
-	/** Starts the upload daemon. */
-	void startUploadDeamon();
 
 	/**  Store assembly counter for id. */
 	int registerAssembly(AssemblyID assemblyId);

--- a/Profiler/UploadDaemon.cpp
+++ b/Profiler/UploadDaemon.cpp
@@ -3,10 +3,9 @@
 #include <shellapi.h>
 #include "utils/WindowsUtils.h"
 
-UploadDaemon::UploadDaemon(std::string profilerPath, Log* log)
+UploadDaemon::UploadDaemon(std::string profilerPath)
 {
 	this->pathToExe = profilerPath + "\\UploadDaemon\\UploadDaemon.exe";
-	this->log = log;
 }
 
 UploadDaemon::~UploadDaemon()
@@ -14,7 +13,25 @@ UploadDaemon::~UploadDaemon()
 	// nothing to do
 }
 
-void UploadDaemon::launch()
+void UploadDaemon::launch(Log* log)
+{
+	bool successful = execute();
+	if (!successful)
+	{
+		log->error("Failed to launch upload daemon " + pathToExe + ": " + WindowsUtils::getLastErrorAsString());
+	}
+}
+
+void UploadDaemon::notifyShutdown()
+{
+	bool successful = execute();
+	if (!successful)
+	{
+		// Cannot log unsuccessful shutdown, because log is already closed at this point.
+	}
+}
+
+bool UploadDaemon::execute()
 {
 	// We need to unset COR_ENABLE_PROFILING so the upload daemon process is not
 	// profiled as well. See https://docs.microsoft.com/en-us/windows/desktop/procthread/changing-environment-variables
@@ -33,10 +50,7 @@ void UploadDaemon::launch()
 	shExecInfo.nShow = SW_NORMAL;
 	shExecInfo.hInstApp = NULL;
 
-	bool successful = ShellExecuteEx(&shExecInfo);
-	if (!successful) {
-		log->error("Failed to launch upload daemon " + pathToExe + ": " + WindowsUtils::getLastErrorAsString());
-	}
+	return ShellExecuteEx(&shExecInfo);
 
 	// We reset the environment of this process. This does not affect the launched child process
 	SetEnvironmentVariable("COR_ENABLE_PROFILING", "1");

--- a/Profiler/UploadDaemon.cpp
+++ b/Profiler/UploadDaemon.cpp
@@ -13,12 +13,12 @@ UploadDaemon::~UploadDaemon()
 	// nothing to do
 }
 
-void UploadDaemon::launch(Log* log)
+void UploadDaemon::launch(Log &log)
 {
 	bool successful = execute();
 	if (!successful)
 	{
-		log->error("Failed to launch upload daemon " + pathToExe + ": " + WindowsUtils::getLastErrorAsString());
+		log.error("Failed to launch upload daemon " + pathToExe + ": " + WindowsUtils::getLastErrorAsString());
 	}
 }
 

--- a/Profiler/UploadDaemon.cpp
+++ b/Profiler/UploadDaemon.cpp
@@ -24,11 +24,9 @@ void UploadDaemon::launch(Log &log)
 
 void UploadDaemon::notifyShutdown()
 {
-	bool successful = execute();
-	if (!successful)
-	{
-		// Cannot log unsuccessful shutdown, because log is already closed at this point.
-	}
+	// Cannot log unsuccessful execution, because log is already closed at this
+	// point (otherwise it could not be uploaded).
+	execute();
 }
 
 bool UploadDaemon::execute()

--- a/Profiler/UploadDaemon.h
+++ b/Profiler/UploadDaemon.h
@@ -15,7 +15,7 @@ public:
 	virtual ~UploadDaemon() noexcept;
 
 	/** Starts the upload daemon in a new background process. */
-	void launch(Log* log);
+	void launch(Log &log);
 
 	/** Notifies the upload daemon that a profiler is shut down. */
 	void notifyShutdown();

--- a/Profiler/UploadDaemon.h
+++ b/Profiler/UploadDaemon.h
@@ -9,13 +9,16 @@ class UploadDaemon {
 public:
 
 	/** Constructor. */
-	UploadDaemon(std::string profilerPath, Log* log);
+	UploadDaemon(std::string profilerPath);
 
 	/** Destructor. */
 	virtual ~UploadDaemon() noexcept;
 
 	/** Starts the upload daemon in a new background process. */
-	void launch();
+	void launch(Log* log);
+
+	/** Notifies the upload daemon that a profiler is shut down. */
+	void notifyShutdown();
 
 private:
 
@@ -24,4 +27,7 @@ private:
 
 	/** Path to the executable of the upload daemon. */
 	std::string pathToExe;
+
+	/** Invoke the upload daemon process */
+	bool execute();
 };

--- a/UploadDaemon/TimerAction.cs
+++ b/UploadDaemon/TimerAction.cs
@@ -2,11 +2,8 @@
 using NLog;
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.IO.Abstractions;
-using System.Text.RegularExpressions;
 using System.Threading.Tasks;
-using System.Timers;
 using UploadDaemon.Upload;
 
 namespace UploadDaemon
@@ -27,14 +24,6 @@ namespace UploadDaemon
             this.config = config;
             this.fileSystem = fileSystem;
             this.uploadFactory = uploadFactory;
-        }
-
-        /// <summary>
-        /// Event handler for the timer event. Runs the action.
-        /// </summary>
-        public void HandleTimerEvent(object sender, ElapsedEventArgs arguments)
-        {
-            Run();
         }
 
         /// <summary>

--- a/UploadDaemon/UploadDaemon.cs
+++ b/UploadDaemon/UploadDaemon.cs
@@ -42,7 +42,7 @@ namespace UploadDaemon
         {
             if (IsAlreadyRunning())
             {
-                Console.WriteLine("Another instance is already running.");
+                logger.Debug("Another instance is already running. Sending notification to trigger upload.");
                 NotifyRunningDaemon();
                 return;
             }

--- a/UploadDaemon/UploadDaemon.cs
+++ b/UploadDaemon/UploadDaemon.cs
@@ -62,7 +62,7 @@ namespace UploadDaemon
 
             logger.Info("Starting upload daemon v{uploaderVersion}", Assembly.GetExecutingAssembly().GetName().Version.ToString());
             var uploader = new UploadDaemon(config);
-            uploader.RunOnce();
+            uploader.UploadOnce();
             uploader.ScheduleRegularUploads();
             uploader.WaitForNotifications();
         }
@@ -94,9 +94,9 @@ namespace UploadDaemon
         }
 
         /// <summary>
-        /// Runs the timer action once synchronously.
+        /// Uploads once, synchronously.
         /// </summary>
-        public void RunOnce()
+        public void UploadOnce()
         {
             lock(SequentialUploadsLock)
             {
@@ -110,7 +110,7 @@ namespace UploadDaemon
         private void ScheduleRegularUploads()
         {
             Timer timer = new Timer();
-            timer.Elapsed += (sender, args) => RunOnce();
+            timer.Elapsed += (sender, args) => UploadOnce();
             timer.Interval = TimerIntervalInMilliseconds;
             timer.Enabled = true;
         }
@@ -130,7 +130,7 @@ namespace UploadDaemon
                         // There is currently only one command (DaemonControlCommandUpload), hence,
                         // we immediately trigger an upload without checking what we received.
                         streamReader.ReadLine();
-                        RunOnce();
+                        UploadOnce();
                     }
                 }
             }

--- a/UploadDaemon/UploadDaemon.cs
+++ b/UploadDaemon/UploadDaemon.cs
@@ -1,7 +1,6 @@
 using Common;
 using NLog;
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.IO.Abstractions;

--- a/UploadDaemon/UploadDaemon.cs
+++ b/UploadDaemon/UploadDaemon.cs
@@ -127,24 +127,12 @@ namespace UploadDaemon
                     pipeServerStream.WaitForConnection();
                     using (var streamReader = new StreamReader(pipeServerStream))
                     {
-                        var command = streamReader.ReadLine();
-                        ExecuteCommand(command);
+                        // There is currently only one command (DaemonControlCommandUpload), hence,
+                        // we immediately trigger an upload without checking what we received.
+                        streamReader.ReadLine();
+                        RunOnce();
                     }
                 }
-            }
-        }
-
-        /// <summary>
-        /// Executes a command forwarded to this UploadDaemon process.
-        /// </summary>
-        /// <param name="command"></param>
-        private void ExecuteCommand(string command)
-        {
-            switch (command)
-            {
-                case DaemonControlCommandUpload:
-                    RunOnce();
-                    break;
             }
         }
 

--- a/UploadDaemon/UploadDaemon.cs
+++ b/UploadDaemon/UploadDaemon.cs
@@ -116,8 +116,7 @@ namespace UploadDaemon
         }
 
         /// <summary>
-        /// Waits for notifications from subsequent executions of the Daemon. Terminates on
-        /// interrupt from the console's cancel key.
+        /// Waits for notifications from subsequent executions of the Daemon.
         /// </summary>
         private void WaitForNotifications()
         {

--- a/UploadDaemon/UploadDaemon.cs
+++ b/UploadDaemon/UploadDaemon.cs
@@ -41,7 +41,8 @@ namespace UploadDaemon
         {
             if (IsAlreadyRunning())
             {
-                logger.Debug("Another instance is already running. Sending notification to trigger upload.");
+                // Writing to console on purpose, to explain to users why the exe terminates immediately.
+                Console.WriteLine("Another instance is already running. Sending notification to trigger upload.");
                 NotifyRunningDaemon();
                 return;
             }

--- a/UploadDaemon/UploadDaemon.cs
+++ b/UploadDaemon/UploadDaemon.cs
@@ -32,7 +32,7 @@ namespace UploadDaemon
         private static readonly Logger logger = LogManager.GetCurrentClassLogger();
 
         private readonly Config config;
-        private readonly TimerAction timerAction;
+        private readonly UploadTask uploadTask;
         private readonly FileSystem fileSystem;
 
         /// <summary>
@@ -90,7 +90,7 @@ namespace UploadDaemon
                 HttpClientUtils.DisableSslValidation();
             }
 
-            timerAction = new TimerAction(config, fileSystem, new UploadFactory());
+            uploadTask = new UploadTask(config, fileSystem, new UploadFactory());
         }
 
         /// <summary>
@@ -100,7 +100,7 @@ namespace UploadDaemon
         {
             lock(SequentialUploadsLock)
             {
-                timerAction.Run();
+                uploadTask.Run();
             }
         }
 

--- a/UploadDaemon/UploadDaemon.cs
+++ b/UploadDaemon/UploadDaemon.cs
@@ -16,7 +16,7 @@ namespace UploadDaemon
     /// <summary>
     /// Main entry point of the program.
     /// </summary>
-    public class Uploader
+    public class UploadDaemon
     {
         private const long TimerIntervalInMilliseconds = 1000 * 60 * 5;
 
@@ -61,7 +61,7 @@ namespace UploadDaemon
             }
 
             logger.Info("Starting upload daemon v{uploaderVersion}", Assembly.GetExecutingAssembly().GetName().Version.ToString());
-            var uploader = new Uploader(config);
+            var uploader = new UploadDaemon(config);
             uploader.RunOnce();
             uploader.ScheduleRegularUploads();
             uploader.WaitForNotifications();
@@ -80,7 +80,7 @@ namespace UploadDaemon
             return Process.GetProcessesByName(current.ProcessName).Where(process => process.Id != current.Id).Any();
         }
 
-        public Uploader(Config config)
+        public UploadDaemon(Config config)
         {
             fileSystem = new FileSystem();
 

--- a/UploadDaemon/UploadDaemon.cs
+++ b/UploadDaemon/UploadDaemon.cs
@@ -125,11 +125,11 @@ namespace UploadDaemon
                 using (var pipeServerStream = new NamedPipeServerStream(DaemonControlPipeName, PipeDirection.In, 1, PipeTransmissionMode.Byte, PipeOptions.Asynchronous))
                 {
                     pipeServerStream.WaitForConnection();
-                    using (var streamReader = new StreamReader(pipeServerStream))
+                    using (var pipeStream = new StreamReader(pipeServerStream))
                     {
                         // There is currently only one command (DaemonControlCommandUpload), hence,
                         // we immediately trigger an upload without checking what we received.
-                        streamReader.ReadLine();
+                        pipeStream.ReadLine();
                         UploadOnce();
                     }
                 }
@@ -145,9 +145,9 @@ namespace UploadDaemon
             {
                 pipeClientStream.Connect();
 
-                using (var w = new StreamWriter(pipeClientStream))
+                using (var pipeStream = new StreamWriter(pipeClientStream))
                 {
-                    w.WriteLine(DaemonControlCommandUpload);
+                    pipeStream.WriteLine(DaemonControlCommandUpload);
                 }
             }
         }

--- a/UploadDaemon/UploadDaemon.csproj
+++ b/UploadDaemon/UploadDaemon.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -82,7 +82,7 @@
     <Compile Include="Upload\TeamscaleUpload.cs" />
     <Compile Include="Upload\UploadServiceUpload.cs" />
     <Compile Include="Upload\AzureUpload.cs" />
-    <Compile Include="Uploader.cs" />
+    <Compile Include="UploadDaemon.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />

--- a/UploadDaemon/UploadDaemon.csproj
+++ b/UploadDaemon/UploadDaemon.csproj
@@ -71,7 +71,7 @@
   <ItemGroup>
     <Compile Include="Archiver.cs" />
     <Compile Include="MessageFormatter.cs" />
-    <Compile Include="TimerAction.cs" />
+    <Compile Include="UploadTask.cs" />
     <Compile Include="TraceFile.cs" />
     <Compile Include="TraceFileScanner.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/UploadDaemon/UploadTask.cs
+++ b/UploadDaemon/UploadTask.cs
@@ -11,7 +11,7 @@ namespace UploadDaemon
     /// <summary>
     /// Triggered any time the timer goes off. Performs the scan and upload/archiving of trace files.
     /// </summary>
-    public class TimerAction
+    public class UploadTask
     {
         private static readonly Logger logger = LogManager.GetCurrentClassLogger();
 
@@ -19,7 +19,7 @@ namespace UploadDaemon
         private readonly IFileSystem fileSystem;
         private readonly IUploadFactory uploadFactory;
 
-        public TimerAction(Config config, IFileSystem fileSystem, IUploadFactory uploadFactory)
+        public UploadTask(Config config, IFileSystem fileSystem, IUploadFactory uploadFactory)
         {
             this.config = config;
             this.fileSystem = fileSystem;

--- a/UploadDaemon/Uploader.cs
+++ b/UploadDaemon/Uploader.cs
@@ -24,6 +24,11 @@ namespace UploadDaemon
 
         private const string DaemonControlCommandUpload = "upload";
 
+        /// <summary>
+        /// Lock used to ensure that no two uploads happen in parallel.
+        /// </summary>
+        private static readonly object SequentialUploadsLock = new object();
+
         private static readonly Logger logger = LogManager.GetCurrentClassLogger();
 
         private readonly Config config;
@@ -103,7 +108,10 @@ namespace UploadDaemon
         /// </summary>
         public void RunOnce()
         {
-            timerAction.Run();
+            lock(SequentialUploadsLock)
+            {
+                timerAction.Run();
+            }
         }
 
         /// <summary>
@@ -135,8 +143,6 @@ namespace UploadDaemon
             switch (command)
             {
                 case DaemonControlCommandUpload:
-                    // TODO (SA) we probably need a lock here, to avoid triggering a second upload
-                    // in parallel. Should we just skip in this case or enqueue a subsequent upload?
                     RunOnce();
                     break;
             }

--- a/UploadDaemon_Test/UploadDaemonSystemTest.cs
+++ b/UploadDaemon_Test/UploadDaemonSystemTest.cs
@@ -1,16 +1,11 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.IO.Abstractions;
-using System.IO.Abstractions.TestingHelpers;
-using System.Linq;
-using Common;
-using Moq;
+﻿using Common;
 using NUnit.Framework;
-using UploadDaemon;
+using System;
+using System.IO;
+using System.Linq;
 
 [TestFixture]
-public class UploaderSystemTest
+public class UploadDaemonSystemTest
 {
     private static DirectoryInfo SolutionRoot =>
         new DirectoryInfo(Path.Combine(TestContext.CurrentContext.TestDirectory, "../../../"));
@@ -43,7 +38,7 @@ public class UploaderSystemTest
 Process=foo.exe
 Inlined=1:33555646:100678050");
 
-        new Uploader(Config.Read($@"
+        new UploadDaemon.UploadDaemon(Config.Read($@"
             match:
               - profiler:
                   targetdir: {TargetDir}

--- a/UploadDaemon_Test/UploadDaemonSystemTest.cs
+++ b/UploadDaemon_Test/UploadDaemonSystemTest.cs
@@ -45,7 +45,7 @@ Inlined=1:33555646:100678050");
                 uploader:
                   versionAssembly: VersionAssembly
                   directory: {UploadDir}
-        ")).RunOnce();
+        ")).UploadOnce();
 
         Assert.Multiple(() =>
         {

--- a/UploadDaemon_Test/UploadDaemon_Test.csproj
+++ b/UploadDaemon_Test/UploadDaemon_Test.csproj
@@ -71,7 +71,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="UploaderSystemTest.cs" />
+    <Compile Include="UploadDaemonSystemTest.cs" />
     <Compile Include="Config\ConfigTest.cs" />
     <Compile Include="Config\ConfigParserTest.cs" />
     <Compile Include="TimerActionTest.cs" />

--- a/UploadDaemon_Test/UploadDaemon_Test.csproj
+++ b/UploadDaemon_Test/UploadDaemon_Test.csproj
@@ -74,7 +74,7 @@
     <Compile Include="UploadDaemonSystemTest.cs" />
     <Compile Include="Config\ConfigTest.cs" />
     <Compile Include="Config\ConfigParserTest.cs" />
-    <Compile Include="TimerActionTest.cs" />
+    <Compile Include="UploadTaskTest.cs" />
     <Compile Include="ArchiverTest.cs" />
     <Compile Include="FileSystemMockingUtils.cs" />
     <Compile Include="TraceFileScannerTest.cs" />

--- a/UploadDaemon_Test/UploadTaskTest.cs
+++ b/UploadDaemon_Test/UploadTaskTest.cs
@@ -1,17 +1,16 @@
-﻿using System.Linq;
+using Common;
+using NUnit.Framework;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Abstractions;
 using System.IO.Abstractions.TestingHelpers;
+using System.Linq;
 using System.Threading.Tasks;
-using Common;
-using Moq;
-using NUnit.Framework;
 using UploadDaemon;
 using UploadDaemon.Upload;
 
 [TestFixture]
-public class TimerActionTest
+public class UploadTaskTest
 {
     private const string TraceDirectory = @"C:\users\public\traces";
     private const string TraceDirectoryWithSpace = @"C:\users\user with spaces\traces";
@@ -37,7 +36,7 @@ Process=foo.exe
 Inlined=1:33555646:100678050" },
         });
 
-        new TimerAction(config, fileSystem, new MockUploadFactory(true)).Run();
+        new UploadTask(config, fileSystem, new MockUploadFactory(true)).Run();
 
         AssertFilesInDirectory(fileSystem, TraceDirectory, @"uploaded\coverage_1_1.txt");
     }
@@ -52,7 +51,7 @@ Process=foo.exe
 Inlined=1:33555646:100678050" },
         });
 
-        new TimerAction(config, fileSystem, new MockUploadFactory(false)).Run();
+        new UploadTask(config, fileSystem, new MockUploadFactory(false)).Run();
 
         AssertFilesInDirectory(fileSystem, TraceDirectory, @"coverage_1_1.txt");
     }
@@ -67,7 +66,7 @@ Process=foo.exe
 Inlined=1:33555646:100678050" },
         });
 
-        new TimerAction(config, fileSystem, new MockUploadFactory(false)).Run();
+        new UploadTask(config, fileSystem, new MockUploadFactory(false)).Run();
 
         AssertFilesInDirectory(fileSystem, TraceDirectory, @"missing-version\coverage_1_1.txt");
     }
@@ -81,7 +80,7 @@ Inlined=1:33555646:100678050" },
 Inlined=1:33555646:100678050" },
         });
 
-        new TimerAction(config, fileSystem, new MockUploadFactory(false)).Run();
+        new UploadTask(config, fileSystem, new MockUploadFactory(false)).Run();
 
         AssertFilesInDirectory(fileSystem, TraceDirectory, @"missing-process\coverage_1_1.txt");
     }
@@ -95,7 +94,7 @@ Inlined=1:33555646:100678050" },
 Process=foo.exe" },
         });
 
-        new TimerAction(config, fileSystem, new MockUploadFactory(true)).Run();
+        new UploadTask(config, fileSystem, new MockUploadFactory(true)).Run();
 
         AssertFilesInDirectory(fileSystem, TraceDirectory, @"empty-traces\coverage_1_1.txt");
     }
@@ -119,7 +118,7 @@ Inlined=1:33555646:100678050" },
                   targetdir: {TraceDirectoryWithSpace}
         ");
 
-        new TimerAction(configWithSpaceInTraceDirectory, fileSystem, new MockUploadFactory(true)).Run();
+        new UploadTask(configWithSpaceInTraceDirectory, fileSystem, new MockUploadFactory(true)).Run();
 
         AssertFilesInDirectory(fileSystem, TraceDirectoryWithSpace, @"uploaded\coverage_1_1.txt");
     }


### PR DESCRIPTION
Fixes #62.

- [ ] Tests written
- [ ] Documentation updated

I prototyped a command forwarding that should allow us to control the `UploadDaemon` from the profiler. I'm unsure whether this solution covers all use cases we have and there's some decision I left open (TODOs in the code), because I lack information to decide what's the right approach. I would appreciate if we could have a talk about this, then it's probably straightforward to complete this.