### PR TITLE
use the correct flag to force a rejit in non-light-mode

### DIFF
--- a/Profiler/CProfilerCallback.cpp
+++ b/Profiler/CProfilerCallback.cpp
@@ -166,7 +166,7 @@ DWORD CProfilerCallback::getEventMask() {
 
 	// disable force re-jitting for the light variant
 	if (!config.shouldUseLightMode()) {
-		dwEventMask |= COR_PRF_MONITOR_ENTERLEAVE;
+		dwEventMask |= COR_PRF_DISABLE_ALL_NGEN_IMAGES;
 	}
 
 	return dwEventMask;


### PR DESCRIPTION
activating enter-leave callbacks is unnecessary and creates an
unnecessary performance overhead

Fixes #89 

- [ ] Tests written -> tested manually against Pinta
- [ ] Documentation updated -> not needed
