### PR TITLE
Fix crashes on Windows 7

### DIFF
--- a/Profiler/CProfilerCallback.cpp
+++ b/Profiler/CProfilerCallback.cpp
@@ -298,7 +298,7 @@ HRESULT CProfilerCallback::JITCompilationFinished(FunctionID functionId,
 }
 
 void CProfilerCallback::handleException(std::string context) {
-	debugLog.logStacktrace(context);
+	debugLog.logErrorWithStracktrace(context);
 	if (!config.shouldIgnoreExceptions()) {
 		throw;
 	}

--- a/Profiler/CProfilerCallback.cpp
+++ b/Profiler/CProfilerCallback.cpp
@@ -123,7 +123,7 @@ void CProfilerCallback::initializeConfig() {
 	if (!configFileWasManuallySpecified) {
 		configFile = Config::getDefaultConfigPath();
 	}
-	Debug::log(configFile);
+	//Debug::log(configFile);
 
 	config.load(configFile, WindowsUtils::getPathOfThisProcess(), configFileWasManuallySpecified);
 }
@@ -181,7 +181,7 @@ UINT_PTR CProfilerCallback::functionMapper(FunctionID functionId, BOOL* pbHookFu
 		return functionId;
 	}
 	catch (...) {
-		Debug::logStacktrace("functionMapper");
+		//Debug::logStacktrace("functionMapper");
 		// since this function must be static, we have no way to access the config so we always terminate the program.
 		throw;
 	}
@@ -298,7 +298,7 @@ HRESULT CProfilerCallback::JITCompilationFinished(FunctionID functionId,
 }
 
 void CProfilerCallback::handleException(std::string context) {
-	Debug::logStacktrace(context);
+	//Debug::logStacktrace(context);
 	if (!config.shouldIgnoreExceptions()) {
 		throw;
 	}

--- a/Profiler/CProfilerCallback.cpp
+++ b/Profiler/CProfilerCallback.cpp
@@ -181,7 +181,6 @@ UINT_PTR CProfilerCallback::functionMapper(FunctionID functionId, BOOL* pbHookFu
 		return functionId;
 	}
 	catch (...) {
-		//Debug::logStacktrace("functionMapper");
 		// since this function must be static, we have no way to access the config so we always terminate the program.
 		throw;
 	}

--- a/Profiler/CProfilerCallback.cpp
+++ b/Profiler/CProfilerCallback.cpp
@@ -3,7 +3,6 @@
 #include "UploadDaemon.h"
 #include "utils/StringUtils.h"
 #include "utils/WindowsUtils.h"
-#include "utils/Debug.h"
 #include <fstream>
 #include <algorithm>
 #include <winuser.h>
@@ -49,6 +48,7 @@ HRESULT CProfilerCallback::Initialize(IUnknown* pICorProfilerInfoUnkown) {
 
 HRESULT CProfilerCallback::InitializeImplementation(IUnknown* pICorProfilerInfoUnkown) {
 	initializeConfig();
+
 	if (!config.isProfilingEnabled()) {
 		return S_OK;
 	}
@@ -123,7 +123,7 @@ void CProfilerCallback::initializeConfig() {
 	if (!configFileWasManuallySpecified) {
 		configFile = Config::getDefaultConfigPath();
 	}
-	//Debug::log(configFile);
+	debugLog.log(configFile);
 
 	config.load(configFile, WindowsUtils::getPathOfThisProcess(), configFileWasManuallySpecified);
 }
@@ -298,7 +298,7 @@ HRESULT CProfilerCallback::JITCompilationFinished(FunctionID functionId,
 }
 
 void CProfilerCallback::handleException(std::string context) {
-	//Debug::logStacktrace(context);
+	debugLog.logStacktrace(context);
 	if (!config.shouldIgnoreExceptions()) {
 		throw;
 	}

--- a/Profiler/CProfilerCallback.h
+++ b/Profiler/CProfilerCallback.h
@@ -3,6 +3,7 @@
 #include "FunctionInfo.h"
 #include "Log.h"
 #include "config/Config.h"
+#include "utils/Debug.h"
 #include "utils/WindowsUtils.h"
 #include <atlbase.h>
 #include <string>
@@ -84,6 +85,9 @@ private:
 
 	/** Smart pointer to the .NET framework profiler info. */
 	CComQIPtr<ICorProfilerInfo2> profilerInfo;
+
+	/** The log to write debug information to. */
+	Debug debugLog;
 
 	/** The log to write all results and messages to. */
 	Log log;

--- a/Profiler/utils/Debug.cpp
+++ b/Profiler/utils/Debug.cpp
@@ -23,7 +23,8 @@ void Debug::log(std::string message)
 	}
 	EnterCriticalSection(&loggingSynchronization);
 	message += "\r\n";
-	WriteFile(logFile, message.c_str(), (DWORD)strlen(message.c_str()), NULL, NULL);
+	DWORD dwWritten = 0;
+	WriteFile(logFile, message.c_str(), (DWORD)strlen(message.c_str()), &dwWritten, NULL);
 	LeaveCriticalSection(&loggingSynchronization);
 }
 

--- a/Profiler/utils/Debug.cpp
+++ b/Profiler/utils/Debug.cpp
@@ -10,26 +10,13 @@ public:
 	}
 };
 
-void Debug::log(std::string message)
-{
-	getInstance().logInternal(message);
-}
-
 Debug::Debug() {
 	InitializeCriticalSection(&loggingSynchronization);
 	logFile = CreateFile("C:\\Users\\Public\\profiler_debug.log", GENERIC_WRITE, FILE_SHARE_READ,
 		NULL, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
 }
 
-Debug::~Debug()
-{
-	if (logFile != INVALID_HANDLE_VALUE) {
-		CloseHandle(logFile);
-	}
-	DeleteCriticalSection(&loggingSynchronization);
-}
-
-void Debug::logInternal(std::string message)
+void Debug::log(std::string message)
 {
 	if (logFile == INVALID_HANDLE_VALUE) {
 		return;
@@ -45,4 +32,12 @@ void Debug::logStacktrace(std::string context) {
 	CustomStackWalker stackWalker;
 	stackWalker.ShowCallstack();
 	log(stackWalker.output);
+}
+
+Debug::~Debug()
+{
+	if (logFile != INVALID_HANDLE_VALUE) {
+		CloseHandle(logFile);
+	}
+	DeleteCriticalSection(&loggingSynchronization);
 }

--- a/Profiler/utils/Debug.cpp
+++ b/Profiler/utils/Debug.cpp
@@ -28,8 +28,8 @@ void Debug::log(std::string message)
 	LeaveCriticalSection(&loggingSynchronization);
 }
 
-void Debug::logStacktrace(std::string context) {
-	log("Stacktrace: " + context);
+void Debug::logErrorWithStracktrace(std::string context) {
+	log("Error in " + context + ". Stacktrace: ");
 	CustomStackWalker stackWalker;
 	stackWalker.ShowCallstack();
 	log(stackWalker.output);

--- a/Profiler/utils/Debug.cpp
+++ b/Profiler/utils/Debug.cpp
@@ -24,7 +24,7 @@ void Debug::log(std::string message)
 	EnterCriticalSection(&loggingSynchronization);
 	message += "\r\n";
 	DWORD dwWritten = 0;
-	WriteFile(logFile, message.c_str(), (DWORD)strlen(message.c_str()), &dwWritten, NULL);
+	WriteFile(logFile, message.c_str(), static_cast<DWORD>(strlen(message.c_str())), &dwWritten, NULL);
 	LeaveCriticalSection(&loggingSynchronization);
 }
 

--- a/Profiler/utils/Debug.h
+++ b/Profiler/utils/Debug.h
@@ -14,8 +14,8 @@ public:
 	/** Logs the given message to the debug log. */
 	void log(std::string message);
 
-	/** Logs the given stack trace to the debug log. */
-	void logStacktrace(std::string context);
+	/** Logs the given context and the current stacktrace to the debug log. */
+	void logErrorWithStracktrace(std::string context);
 
 	virtual ~Debug();
 private:

--- a/Profiler/utils/Debug.h
+++ b/Profiler/utils/Debug.h
@@ -9,32 +9,16 @@
 class Debug
 {
 public:
-	/** Logs the given message to the debug log. */
-	static void log(std::string message);
-
-	/** Logs the current stack trace. */
-	static void logStacktrace(std::string context);
-
-	virtual ~Debug();
-
-private:
 	Debug();
 
-	void logInternal(std::string message);
+	/** Logs the given message to the debug log. */
+	void log(std::string message);
 
-	/**
-	 * Implements a thread-safe singleton pattern and ensures that the instance
-	 * is properly destroyed and thus the file handle freed.
-	 * See https://stackoverflow.com/a/1008289/1396068
-	 */
-	static Debug& getInstance()
-	{
-		// Guaranteed to be destroyed.
-		// Instantiated on first use.
-		static Debug instance;
-		return instance;
-	}
+	/** Logs the given stack trace to the debug log. */
+	void logStacktrace(std::string context);
 
+	virtual ~Debug();
+private:
 	HANDLE logFile = INVALID_HANDLE_VALUE;
 	CRITICAL_SECTION loggingSynchronization;
 };


### PR DESCRIPTION
Fixes #125 

Turns out the problem was that we pass NULL to the "number of characters written" parameter of `WriteFile`, which is apparently valid under Win10, but not Win7. We now pass a reference and, voila, all works fine under Win7 again as well.

Unfortunately, AppVeyor doesn't seem to provide an image for running CI on Win7 as well...

No Teamscale findings.