### PR TITLE
Async uploads never happen

### DIFF
--- a/UploadDaemon/Upload/TeamscaleUpload.cs
+++ b/UploadDaemon/Upload/TeamscaleUpload.cs
@@ -90,34 +90,23 @@ namespace UploadDaemon.Upload
             {
                 timestampParameter = "t";
             }
-            logger.Debug("Uploading line coverage from {trace} with {parameter}={parameterValue} to {teamscale}",
-                originalTraceFilePath, timestampParameter, revisionOrTimestamp.Value, server.ToString());
 
-            string url;
-            try
-            {
-                string message = messageFormatter.Format(timestampParameter);
-                string encodedMessage = HttpUtility.UrlEncode(message);
-                string encodedProject = HttpUtility.UrlEncode(server.Project);
-                string encodedTimestamp = HttpUtility.UrlEncode(revisionOrTimestamp.Value);
-                string encodedPartition = HttpUtility.UrlEncode(server.Partition);
-                url = $"{server.Url}/p/{encodedProject}/external-report?format=SIMPLE" +
-                    $"&message={encodedMessage}&partition={encodedPartition}&adjusttimestamp=true&movetolastcommit=true" +
-                    $"&{timestampParameter}={encodedTimestamp}";
-            }
-            catch (Exception e)
-            {
-                logger.Error(e, "Failed to prepare upload parameters");
-                return false;
-            }
+            string message = messageFormatter.Format(timestampParameter);
+            string encodedMessage = HttpUtility.UrlEncode(message);
+            string encodedProject = HttpUtility.UrlEncode(server.Project);
+            string encodedTimestamp = HttpUtility.UrlEncode(revisionOrTimestamp.Value);
+            string encodedPartition = HttpUtility.UrlEncode(server.Partition);
+            string url = $"{server.Url}/p/{encodedProject}/external-report?format=SIMPLE" +
+                $"&message={encodedMessage}&partition={encodedPartition}&adjusttimestamp=true&movetolastcommit=true" +
+                $"&{timestampParameter}={encodedTimestamp}";
+
+            logger.Debug("Uploading line coverage from {trace} to {teamscale} ({url})", originalTraceFilePath, server.ToString(), url);
 
             try
             {
-                logger.Debug("Starting upload of line coverage to {url}", url);
                 byte[] reportBytes = Encoding.UTF8.GetBytes(lineCoverageReport);
                 using (MemoryStream stream = new MemoryStream(reportBytes))
                 {
-                    logger.Debug("Loaded data, sending request.");
                     return await PerformLineCoverageUpload(originalTraceFilePath, timestampParameter, revisionOrTimestamp.Value, url, stream);
                 }
             }

--- a/UploadDaemon/UploadDaemon.cs
+++ b/UploadDaemon/UploadDaemon.cs
@@ -104,7 +104,7 @@ namespace UploadDaemon
             lock (SequentialUploadsLock)
             {
                 var fileSystem = new FileSystem();
-                new UploadTask(fileSystem, new UploadFactory(), new LineCoverageSynthesizer()).Run(config).Wait();
+                new UploadTask(fileSystem, new UploadFactory(), new LineCoverageSynthesizer()).Run(config);
                 new PurgeArchiveTask(new ArchiveFactory(fileSystem, new DefaultDateTimeProvider())).Run(config);
             }
         }

--- a/UploadDaemon/UploadDaemon.cs
+++ b/UploadDaemon/UploadDaemon.cs
@@ -104,7 +104,7 @@ namespace UploadDaemon
             lock (SequentialUploadsLock)
             {
                 var fileSystem = new FileSystem();
-                new UploadTask(fileSystem, new UploadFactory(), new LineCoverageSynthesizer()).Run(config);
+                new UploadTask(fileSystem, new UploadFactory(), new LineCoverageSynthesizer()).Run(config).Wait();
                 new PurgeArchiveTask(new ArchiveFactory(fileSystem, new DefaultDateTimeProvider())).Run(config);
             }
         }

--- a/UploadDaemon/UploadTask.cs
+++ b/UploadDaemon/UploadTask.cs
@@ -33,7 +33,7 @@ namespace UploadDaemon
         /// <summary>
         /// Scans the trace directories for traces to process and either tries to upload or archive them.
         /// </summary>
-        public async void Run(Config config)
+        public async Task Run(Config config)
         {
             foreach (string traceDirectory in config.TraceDirectoriesToWatch)
             {


### PR DESCRIPTION
Fixes another async issue.

- Not sure how to test async behavior...
- No documentation update (bug fix)

We again had a problem with a missing await. This time it was even harder to spot, because it was the `async void Run()` method of the `UploadTask`. Note: `async void` is intended _only_ for event handlers (such that UI elements stay responsive) and should never be used in our case. In fact, we don't want asynchronous behavior at all, but always want to wait for uploads to finish, because otherwise uploads may not happen before the daemon terminates (as it happened in this case) or even happen in parallel on the same trace files. Therefore, we now explicitly wait for all uploads to finish immediately at the respective call sites, which also prevents `await/async` to unnecessarily infest our entire codebase...