### PR TITLE
Provide simple installation script

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -53,6 +53,9 @@ after_test:
   - cmd: robocopy .\Profiler\bin\Release teamscale_dotnet_profiler *.dll *.pdb & exit 0
   # copy example config
   - cmd: robocopy .\Profiler teamscale_dotnet_profiler Profiler.example.yml & exit 0
+  # copy install script
+  - cmd: robocopy .\Profiler install.cmd install.cmd & exit 0
+  - cmd: robocopy .\Profiler install.example.cfg install.example.cfg & exit 0
   # copy UploadDaemon
   - cmd: robocopy .\Profiler\bin\Release\UploadDaemon teamscale_dotnet_profiler\UploadDaemon *.* /xf *.pdb & exit 0
   - cmd: mkdir teamscale_dotnet_profiler\UploadDaemon\service

--- a/Profiler/install.cmd
+++ b/Profiler/install.cmd
@@ -1,0 +1,79 @@
+@echo off
+setlocal EnableDelayedExpansion
+
+rem check for admin rights
+net session >nul 2>&1
+if %errorLevel% NEQ 0 (
+	echo Failure: Execute script as Administrator.
+	pause
+	exit /B 1
+)
+
+
+set InstallSource=%CD%
+for /f "delims=" %%x in (%InstallSource%\install.cfg) do (
+	set line=%%x
+	if "!line:~0,1!" neq "#" (
+		set !line!
+	)
+)
+
+if "%InstallDir%"=="" (
+	echo Failure: InstallDir not set.
+	pause
+	exit /B 1
+)
+
+echo Installing Profiler to: "%InstallDir%"
+
+if exist "%InstallDir%" (
+	if "%InstallUploadService%"=="true" (
+		echo Uninstalling Upload Service
+		pushd "%InstallDir%\UploadDaemon\service"
+		UploadDaemonService stop
+		UploadDaemonService uninstall
+		popd
+	)
+) else (
+	mkdir "%InstallDir%"
+)
+
+xcopy "%InstallSource%" "%InstallDir%" /e /y /q
+
+if exist "%PROGRAMFILES(X86)%" (
+	copy "%InstallDir%\Profiler64.dll" "%SystemRoot%\System32\TeamscaleProfiler.dll" /y
+	copy "%InstallDir%\Profiler32.dll" "%SystemRoot%\SysWOW64\TeamscaleProfiler.dll" /y
+) else (
+	copy "%InstallDir%\Profiler32.dll" "%SystemRoot%\System32\TeamscaleProfiler.dll" /y
+)
+
+setx /m COR_PROFILER {DD0A1BB6-11CE-11DD-8EE8-3F9E55D89593}
+
+REM Enable the profiler globally (the actual profiling is disabled in the Profiler.yml)
+setx /m COR_ENABLE_PROFILING 1
+setx /m CORCLR_ENABLE_PROFILING 1
+
+REM Path to profiler DLL, this points to the 64-Bit dll, located in System32. It will automatically redirect to SysWOW64 for 32-Bit applications.
+setx /m COR_PROFILER_PATH "%SystemRoot%\System32\TeamscaleProfiler.dll"
+REM Register profiling for .net core, we can use the install location here
+setx /m CORECLR_PROFILER_PATH_32 "%InstallDir%\Profiler32.dll"
+setx /m CORECLR_PROFILER_PATH_64 "%InstallDir%\Profiler64.dll"
+
+REM Path to profiler config file (same for .net std fw and core)
+setx /m COR_PROFILER_CONFIG "%InstallDir%\Profiler.yml"
+
+if "%InstallUploadService%"=="1" (
+	echo Installing Upload Service
+	pushd "%InstallDir%\UploadDaemon\service"
+	UploadDaemonService install
+	UploadDaemonService start
+	popd
+)
+
+echo.
+echo ======================================
+echo Success: Teamscale Profiler installed.
+echo ======================================
+echo.
+
+pause

--- a/Profiler/install.example.cfg
+++ b/Profiler/install.example.cfg
@@ -1,0 +1,5 @@
+# The path to install the profiler into
+InstallDir=C:\tsp
+
+# Whether to install the upload service
+InstallUploadService=true


### PR DESCRIPTION
This PR provides an simple installation script for the profiler. However, I am not sure if it should be part of the official distribution, so maybe let's discuss this 1st and if we keep it what must be 1) documented and 2) which features are missing.

Installation currently offers two steps:

1) Installation of the profiler for the whole system (and thus being configurable via YML). It will be installed in a way that 32bit, 64bit and DNX can be profiled at the same time.

2) Installation of the upload service.

The installation offers simple configuration by a properties file (install.cfg). 