### PR TITLE
TS-47232 Warn about misspelled profiler option names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Please prefix each entry with one of:
 - [breaking change] Removed feature to upload raw .NET trace files
 - [feature] Support for recording and uploading Testwise Coverage
 - [fix] .NET Framework subprocesses were not traced when UploadDaemon was active
+- [fix] Misspelled profiler option names in the config file were silently ignored, they are now reported as a warning in the trace file
 
 # v25.12.0
 - [fix] Removed feature to upload coverage to multiple Teamscale projects via embedded resources, as it unexpectedly locked DLL files

--- a/Profiler/CProfilerCallback.cpp
+++ b/Profiler/CProfilerCallback.cpp
@@ -114,6 +114,10 @@ namespace Profiler {
 
 		traceLog.createLogFile(config.getTargetDir());
 		traceLog.info("looking for configuration options in: " + config.getConfigPath());
+		// must happen before the problems are logged as those terminate the process
+		for (const std::string& warning : config.getWarnings()) {
+			traceLog.warn(warning);
+		}
 		for (const std::string& problem : config.getProblems()) {
 			traceLog.error(problem);
 			std::cerr << problem;

--- a/Profiler/config/Config.cpp
+++ b/Profiler/config/Config.cpp
@@ -98,6 +98,28 @@ namespace Profiler {
 		}
 
 		disableProfilerIfProcessSuffixDoesntMatch();
+
+		// must happen last so all supported options have been queried by now
+		warnAboutUnknownOptions();
+	}
+
+	void Config::warnAboutUnknownOptions() {
+		// We only inspect the sections that apply to the profiled process. Typos in the sections of other
+		// processes are not reported as every process would otherwise warn about every other process's options.
+		CaseInsensitiveStringSet unknownOptionNames;
+		for (ProcessSection& section : relevantConfigFileSections) {
+			for (const auto& option : section.profilerOptions) {
+				if (queriedOptionNames.find(option.first) == queriedOptionNames.end()) {
+					unknownOptionNames.insert(option.first);
+				}
+			}
+		}
+
+		// the same option may be misspelled in several matching sections, so we warn only once per option name
+		for (const std::string& optionName : unknownOptionNames) {
+			warnings.push_back("Unknown profiler option '" + optionName
+				+ "' in the config file. Please check the spelling. This option is ignored.");
+		}
 	}
 
 	void Config::disableProfilerIfProcessSuffixDoesntMatch() {
@@ -108,6 +130,11 @@ namespace Profiler {
 	}
 
 	std::string Config::getOption(std::string optionName) {
+		// Remembering the queried options here relieves us of maintaining a separate list of all supported
+		// option names, which would silently go stale. warnAboutUnknownOptions reports everything that's left.
+		// This requires that setOptions queries every supported option unconditionally.
+		queriedOptionNames.insert(optionName);
+
 		std::string value = environmentVariableReader(optionName);
 		if (!value.empty()) {
 			return value;

--- a/Profiler/config/Config.h
+++ b/Profiler/config/Config.h
@@ -27,9 +27,14 @@ namespace Profiler {
 		/** Loads the config from the given YAML stream and applies all sections that apply to the given profiled process path. */
 		void EXPOSE_TO_CPP_TESTS load(std::istream& configFileContents, std::string processPath);
 
-		/** Returns any problems encountered while loading the config, e.g. to log them. */
+		/** Returns any problems encountered while loading the config, e.g. to log them. These are fatal and abort the profiled process. */
 		std::vector<std::string> getProblems() {
 			return problems;
+		}
+
+		/** Returns any non-fatal warnings encountered while loading the config, e.g. to log them. */
+		std::vector<std::string> getWarnings() {
+			return warnings;
 		}
 
 		/** The path to the config file. */
@@ -103,6 +108,10 @@ namespace Profiler {
 		std::vector<ProcessSection> relevantConfigFileSections;
 		EnvironmentVariableReader* environmentVariableReader;
 		std::vector<std::string> problems;
+		std::vector<std::string> warnings;
+
+		/** The names of all options the profiler asked for, i.e. all options it supports. Filled by getOption. */
+		CaseInsensitiveStringSet queriedOptionNames;
 
 		bool enabled;
 		std::string targetDir;
@@ -121,6 +130,12 @@ namespace Profiler {
 		std::string getOption(std::string key);
 		bool getBooleanOption(std::string key, bool defaultValue);
 		void setOptions();
+
+		/**
+		 * Logs a warning for every option in the config file that the profiler doesn't support, e.g. because its name is misspelled.
+		 * Must be called after all supported options have been queried via getOption.
+		 */
+		void warnAboutUnknownOptions();
 		void loadYamlConfig(std::istream& configFileContents);
 		bool sectionMatches(ProcessSection& section);
 

--- a/Profiler/utils/StringUtils.h
+++ b/Profiler/utils/StringUtils.h
@@ -3,6 +3,7 @@
 #include <string>
 #include <algorithm>
 #include <map>
+#include <set>
 #include "Testing.h"
 
 namespace Profiler {
@@ -39,5 +40,8 @@ namespace Profiler {
 
 	/** A map string -> string that ignores the casing of its keys. */
 	typedef std::map<std::string, std::string, StringUtils::CaseInsensitiveComparator> CaseInsensitiveStringMap;
+
+	/** A set of strings that ignores the casing of its entries. */
+	typedef std::set<std::string, StringUtils::CaseInsensitiveComparator> CaseInsensitiveStringSet;
 }
 

--- a/Profiler_Cpp_Test/tests/ConfigTest.cpp
+++ b/Profiler_Cpp_Test/tests/ConfigTest.cpp
@@ -280,6 +280,24 @@ match:
 		Assert::AreEqual(size_t(0), config.getWarnings().size(), L"sections of other processes must not be inspected");
 	}
 
+	TEST_METHOD(MustNotWarnAboutUploaderSection)
+	{
+		// The uploader section is consumed by the UploadDaemon and not by the profiler,
+		// so none of its options may be reported as unknown.
+		Config config = parse(R"(
+match:
+  - executablePathRegex: ".*"
+    profiler:
+      light_mode: false
+    uploader:
+      pdbDirectory: '@AssemblyDir'
+      revisionFile: '@AssemblyDir\revision.txt'
+)", emptyEnvironment);
+
+		Assert::AreEqual(size_t(0), config.getWarnings().size(), L"the uploader section must not be inspected");
+		Assert::AreEqual(false, config.shouldUseLightMode(), L"the profiler section must still be applied");
+	}
+
 	TEST_METHOD(AllSupportedOptionsMustBeRecognized)
 	{
 		// This list documents all options the profiler supports. It is deliberately duplicated here and

--- a/Profiler_Cpp_Test/tests/ConfigTest.cpp
+++ b/Profiler_Cpp_Test/tests/ConfigTest.cpp
@@ -1,4 +1,5 @@
 #include <sstream>
+#include <vector>
 #include "CppUnitTest.h"
 #include "config/Config.h"
 
@@ -224,7 +225,94 @@ match:
 		Assert::AreEqual(false, config.shouldUseLightMode(), L"should not use light mode when overwritten in config file");
 	}
 
+	TEST_METHOD(MustWarnAboutUnknownProfilerOption)
+	{
+		Config config = parse(R"(
+match:
+  - executablePathRegex: ".*"
+    profiler:
+      light_mdoe: false
+)", emptyEnvironment);
+
+		Assert::AreEqual(size_t(1), config.getWarnings().size(), L"number of warnings");
+		Assert::AreEqual(size_t(0), config.getProblems().size(), L"a misspelled option must not be fatal");
+		Assert::AreEqual(true, config.shouldUseLightMode(), L"the misspelled option must still be ignored");
+	}
+
+	TEST_METHOD(MustNotWarnAboutKnownProfilerOptions)
+	{
+		Config config = parse(R"(
+match:
+  - executablePathRegex: ".*"
+    profiler:
+      LIGHT_MODE: false
+      Ignore_Exceptions: true
+)", emptyEnvironment);
+
+		Assert::AreEqual(size_t(0), config.getWarnings().size(), L"options must be recognized regardless of their casing");
+		Assert::AreEqual(false, config.shouldUseLightMode(), L"should not use light mode");
+	}
+
+	TEST_METHOD(MustWarnOnlyOnceAboutTheSameUnknownOption)
+	{
+		Config config = parse(R"(
+match:
+  - executablePathRegex: ".*"
+    profiler:
+      light_mdoe: false
+  - executablePathRegex: ".*\\program.exe"
+    profiler:
+      light_mdoe: true
+)", emptyEnvironment);
+
+		Assert::AreEqual(size_t(1), config.getWarnings().size(), L"the same option must not be reported per section");
+	}
+
+	TEST_METHOD(MustNotWarnAboutUnknownOptionsInNonMatchingSections)
+	{
+		Config config = parse(R"(
+match:
+  - executableName: "other.exe"
+    profiler:
+      light_mdoe: false
+)", emptyEnvironment);
+
+		Assert::AreEqual(size_t(0), config.getWarnings().size(), L"sections of other processes must not be inspected");
+	}
+
+	TEST_METHOD(AllSupportedOptionsMustBeRecognized)
+	{
+		// This list documents all options the profiler supports. It is deliberately duplicated here and
+		// not in the profiler itself: the profiler derives the supported options from the ones it queries,
+		// so it can never go stale. This test detects when an option is no longer queried unconditionally
+		// from Config::setOptions, which would make the profiler warn about a perfectly valid option.
+		const std::vector<std::string> supportedOptions = {
+			"targetdir", "enabled", "light_mode", "assembly_file_version", "assembly_paths",
+			"dump_environment", "ignore_exceptions", "upload_daemon", "tga", "tia",
+			"tia_request_socket", "eagerness"
+		};
+
+		std::stringstream yaml;
+		yaml << "match:\n  - executablePathRegex: \".*\"\n    profiler:\n";
+		for (const std::string& option : supportedOptions) {
+			yaml << "      " << option << ": \"1\"\n";
+		}
+
+		Config config = parse(yaml.str(), emptyEnvironment);
+
+		Assert::AreEqual(size_t(0), config.getWarnings().size(), describe(config.getWarnings()).c_str());
+	}
+
 private:
+
+	/** Turns the given messages into an assertion message so a failure names the offending options. */
+	static std::wstring describe(const std::vector<std::string>& messages) {
+		std::string description = "unexpected warnings:";
+		for (const std::string& message : messages) {
+			description += " " + message;
+		}
+		return std::wstring(description.begin(), description.end());
+	}
 
 	Config parse(std::string yaml, EnvironmentVariableReader* reader) {
 		Config config(reader);

--- a/Profiler_Test/ProfilerTest.cs
+++ b/Profiler_Test/ProfilerTest.cs
@@ -170,12 +170,6 @@ match:
       tga: true
       eagerness: 0
     uploader:
-      teamscale:
-        url: http://localhost:8080
-        username: build
-        accessKey: some-access-key
-        project: some-project
-        partition: Manual Tests
       pdbDirectory: '@AssemblyDir'
       assemblyPatterns:
         include:

--- a/Profiler_Test/ProfilerTest.cs
+++ b/Profiler_Test/ProfilerTest.cs
@@ -125,6 +125,71 @@ match:       [{{profiler: {{enabled         : false}}}}, {{executablePathRegex: 
         }
 
         /// <summary>
+        /// Makes sure that an option whose name the profiler doesn't know is reported as a warning in the trace file.
+        /// The testee must still run to completion, which is asserted implicitly by Testee.Run.
+        /// </summary>
+        [Test]
+        public void TestWarnsAboutUnknownConfigOption()
+        {
+            var configFile = Path.Combine(TestTempDirectory, "profilerconfig.yml");
+            File.WriteAllText(configFile, @"
+match:
+  - profiler:
+      enabled: true
+      light_mdoe: false
+");
+            profiler.ConfigFilePath = configFile;
+
+            new Testee(GetTestProgram("ProfilerTestee.exe")).Run(profiler, arguments: "none");
+
+            string[] lines = profiler.GetSingleTrace();
+            Assert.That(lines, Has.Some.StartsWith("Warn=Unknown profiler option 'light_mdoe'"));
+        }
+
+        /// <summary>
+        /// Makes sure that a valid config file causes no warnings at all. This includes the options of the
+        /// uploader, which are consumed by the UploadDaemon and not by the profiler.
+        /// </summary>
+        [Test]
+        public void TestDoesNotWarnAboutValidConfig()
+        {
+            var configFile = Path.Combine(TestTempDirectory, "profilerconfig.yml");
+            File.WriteAllText(configFile, @"
+disableSslValidation: true
+uploadIntervalInMinutes: 5
+archivePurgingThresholdsInDays:
+  uploadedTraces: 7
+  emptyTraces: 3
+  incompleteTraces: 3
+match:
+  - profiler:
+      enabled: true
+      light_mode: true
+      assembly_paths: true
+      ignore_exceptions: false
+      tga: true
+      eagerness: 0
+    uploader:
+      teamscale:
+        url: http://localhost:8080
+        username: build
+        accessKey: some-access-key
+        project: some-project
+        partition: Manual Tests
+      pdbDirectory: '@AssemblyDir'
+      assemblyPatterns:
+        include:
+          - ProfilerTestee*
+");
+            profiler.ConfigFilePath = configFile;
+
+            new Testee(GetTestProgram("ProfilerTestee.exe")).Run(profiler, arguments: "none");
+
+            string[] lines = profiler.GetSingleTrace();
+            Assert.That(lines, Has.None.StartsWith("Warn="));
+        }
+
+        /// <summary>
         /// Makes sure that when tga mode is active, we only get regular coverage.
         /// </summary>
         [Test]


### PR DESCRIPTION
Options in a profiler: section of the config file were silently ignored when their name was unknown, e.g. light_mdoe instead of light_mode. The profiler then behaved as if the option had never been set, with no diagnostic at all.

Config now collects the names of all options it queries and reports everything left over in the matching sections as a warning. Deriving the list of supported options this way instead of hard-coding it means it can never go stale, which would make the profiler warn about valid options.

The warnings go to a separate vector rather than to the existing problems vector, as the latter terminates the profiled process. They are logged before the problems for that same reason.

Addresses issue [TS-47232](https://jira.cqse.eu/browse/TS-47232)

- [x] Tests written
- [x] Documentation updated
- [x] `CHANGELOG.md` updated
- [x] Present new features in [N&N](https://wiki.cqse.eu/pages/viewpage.action?pageId=689566)

Please respect the [Teamscale](https://demo.teamscale.com/activity.html#/teamscale-net-profiler) vote. Clean up findings before sending your change into review. Blacklist and report false-positives. Adjust the analysis profile if needed.
